### PR TITLE
Landing and about page tenant use community name

### DIFF
--- a/client/src/components/help/about.vue
+++ b/client/src/components/help/about.vue
@@ -19,15 +19,15 @@
       </b-col>
 
       <b-col cols="6" class="d-flex">
-        <b-jumbotron text-variant="white" :style="{ backgroundColor: tenantData.tenant[0]?.color || secondary }" class="w-100 d-flex flex-column">
+        <b-jumbotron text-variant="white" :style="{ backgroundColor: currentTenant.color || secondary }" class="w-100 d-flex flex-column">
           <template #header>
 <!--            <span class="text-white">You are on {{ this.tenantData.tenant[0].community }}</span>-->
-            <span class="text-white">You are on {{ this.tenantData.tenant[0]?.community }}</span>
+            <span class="text-white">You are on {{ currentTenant.community }}</span>
           </template>
 
           <template #lead>
             <span class="p-5 flex-grow-1">
-              {{ this.tenantData.tenant[0]?.description }}
+              {{ currentTenant.description }}
             </span>
           </template>
         </b-jumbotron>
@@ -95,9 +95,9 @@ in case more intro paragraph text is needed
     <b-container fluid="md" class="mt-5">
       <h2>
          <a
-          :href="tenantData.tenant[0].url"
+          :href="currentTenant.url"
           target="_blank"
-          >{{ this.tenantData.tenant[0].community }}</a
+          >{{ currentTenant.community }}</a
         >
       </h2>
       <h5>Repositories crawled and indexed</h5>
@@ -247,7 +247,15 @@ export default {
     ...mapGetters(["appVersion", "appDate", "getTenantData"]),
     tenantData() {
       return this.$store.getters.getTenantData;
-      //  use community then get title, url
+    },
+    currentCommunity() {
+      return this.FacetsConfig.COMMUNITY;
+    },
+    currentTenant() {
+      if (!this.tenantData?.tenant) return null;
+      return this.tenantData.tenant.find(
+        t => t.community === this.currentCommunity
+      ) || null;
     },
     bgColor() {
       return this.generateColorFromTitle("Geochemistry");

--- a/client/src/components/landing/landing.vue
+++ b/client/src/components/landing/landing.vue
@@ -2,8 +2,12 @@
   <b-container fluid="md" class="mt-5">
     <!-- allow logo to size according to container. fill with primary color from bootstrap variables -->
     <b-container class="col-md-5 pt-5">
-      <logoGeoCodes v-if="!this.tenantData" fill="#18598b" width="100%" />
-      <span v-if="this.tenantData" class="logo">{{this.tenantData.tenant[0].community}}</span>
+      <template v-if="currentTenant">
+        <span class="logo">{{ currentTenant.community }}</span>
+      </template>
+       <template v-else>
+        <logoGeoCodes fill="#18598b" width="100%" />
+      </template>
     </b-container>
 
     <b-container class="col-md-5 mt-4">
@@ -64,7 +68,7 @@
       </b-form>
     </b-container>
 
-    <b-container v-if="this.tenantData" fluid="md" class="mt-5">
+    <b-container v-if="currentTenant" fluid="md" class="mt-5">
       <b-carousel
         id="carousel-landing"
         v-model="slide"
@@ -73,8 +77,7 @@
         indicators
       >
         <b-carousel-slide>
-          {{ this.tenantData.tenant[0].landing_introduction }}
-<!--          <span class="text-nowrap">and tool search engine</span>-->
+          {{ currentTenant.landing_introduction }}
         </b-carousel-slide>
 <!--        <b-carousel-slide> a schema.org/Dataset search </b-carousel-slide>-->
 <!--        <b-carousel-slide>-->
@@ -190,6 +193,15 @@ export default {
   },
   computed: {
     ...mapState(["FacetsConfig"]),
+    currentCommunity() {
+      return this.FacetsConfig.COMMUNITY;
+    },
+    currentTenant() {
+      if (!this.tenantData?.tenant) return null;
+      return this.tenantData.tenant.find(
+        t => t.community === this.currentCommunity
+      ) || null;
+    },
     tenantData() {
       return this.$store.getters.getTenantData;
     }


### PR DESCRIPTION
Landing and about page's tenant data should use community name for configuration instead of hard coding the first element