### PR TITLE
Update Search2 result cards and search-scoped facet counts

### DIFF
--- a/client/.env
+++ b/client/.env
@@ -1,5 +1,0 @@
-VITE_APP_MAPBOX_API_KEY=pk.eyJ1IjoidmFsZW50aW5lZHd2IiwiYSI6ImNscnNoNmFncjA3OHcycW8zNXJ4Z3BkNTAifQ.XvgsPncdJRXKsODCheRANA
-
-VITE_APP_FACETS_CONFIG_FILE=config/config_qlever_and_or.yaml
-#NODE_OPTIONS=--openssl-legacy-provider
-VITE_APP_TITLE=GeoCodes

--- a/client/public/config/config_qlever_and_or.yaml
+++ b/client/public/config/config_qlever_and_or.yaml
@@ -123,11 +123,11 @@ FACETS:
     sort: acs
     open: true
     type: rangeyear
-  - field: spatialCoverage
-    title: Spatial Filter
-    sort: acs
-    open: true
-    type: geo
+#  - field: spatialCoverage
+#    title: Spatial Filter
+#    sort: acs
+#    open: true
+#    type: geo
 #  - field: variableMeasured
 #    title: Variables Measured
 #    sort: acs

--- a/client/src/components/facetsearch/ResultHeader2.vue
+++ b/client/src/components/facetsearch/ResultHeader2.vue
@@ -7,6 +7,10 @@
             <b-spinner small class="me-2"></b-spinner>
             Searching...
           </span>
+          <span v-else-if="hasFilters && searchTotalCount > totalCount">
+            Showing {{ totalCount.toLocaleString() }} of
+            {{ searchTotalCount.toLocaleString() }} results
+          </span>
           <span v-else-if="totalCount > currentCount">
             Showing {{ currentCount.toLocaleString() }} of
             {{ totalCount.toLocaleString() }} results
@@ -54,6 +58,10 @@ export default {
       default: 0
     },
     totalCount: {
+      type: Number,
+      default: 0
+    },
+    searchTotalCount: {
       type: Number,
       default: 0
     },

--- a/client/src/components/facetsearch/ResultHeader2.vue
+++ b/client/src/components/facetsearch/ResultHeader2.vue
@@ -7,9 +7,13 @@
             <b-spinner small class="me-2"></b-spinner>
             Searching...
           </span>
+          <span v-else-if="totalCount > currentCount">
+            Showing {{ currentCount.toLocaleString() }} of
+            {{ totalCount.toLocaleString() }} results
+          </span>
           <span v-else>
-            {{ currentCount.toLocaleString() }}
-            {{ currentCount === 1 ? 'result' : 'results' }}
+            {{ resultLabelCount.toLocaleString() }}
+            {{ resultLabelCount === 1 ? 'result' : 'results' }}
           </span>
         </h5>
 
@@ -61,6 +65,12 @@ export default {
       type: Boolean,
       default: false
     }
+  },
+
+  computed: {
+    resultLabelCount() {
+      return this.totalCount > 0 ? this.totalCount : this.currentCount;
+    },
   },
 
   setup(props) {

--- a/client/src/components/facetsearch/ResultItem2.vue
+++ b/client/src/components/facetsearch/ResultItem2.vue
@@ -1,95 +1,97 @@
 <template>
-  <b-card class="result-item">
-    <div class="d-flex">
-      <div class="flex-grow-1">
-        <h6 class="result-title">
-          <router-link
-            :to="getResultLink(result)"
-            class="text-decoration-none"
-          >
-            {{ result.name || 'Untitled' }}
-          </router-link>
-          <b-badge
-            :variant="getResourceTypeVariant(result.resourceType)"
-            class="ms-2"
-          >
-            {{ result.resourceType || 'data' }}
-          </b-badge>
-        </h6>
+  <b-card
+    tag="article"
+    class="rounded-0 result-item-master"
+    :class="['type_' + resourceTypeLower]"
+    @click="showDetails"
+  >
+    <router-link :to="resultLink" @click.stop>
+      <b-card-title class="name"><span v-html="displayName"></span></b-card-title>
+    </router-link>
+    <b-card-title
+      v-if="result.pubname"
+      class="publisher"
+      ><span v-html="result.pubname"></span></b-card-title
+    >
 
-        <p class="result-description text-muted">
-          {{ truncateText(result.description || 'No description available', 200) }}
-        </p>
+    <b-card-text
+      v-if="result.description"
+      class="description small mb-2"
+      ><span v-html="result.description"></span></b-card-text
+    >
 
-        <div class="result-metadata">
-          <small class="text-muted">
-            <span v-if="result.pubname" class="me-3">
-              <i class="fas fa-building me-1"></i>
-              {{ result.pubname }}
-            </span>
-            <span v-if="result.datep" class="me-3">
-              <i class="fas fa-calendar me-1"></i>
-              {{ formatDate(result.datep) }}
-            </span>
-            <span v-if="result.placename && result.placename !== 'No Placenames'" class="me-3">
-              <i class="fas fa-map-marker-alt me-1"></i>
-              {{ result.placename }}
-            </span>
-          </small>
-        </div>
-
-        <div v-if="result.keywords && result.keywords.length > 0" class="result-keywords mt-2">
-          <b-badge
-            v-for="keyword in result.keywords.slice(0, 5)"
-            :key="keyword"
-            variant="light"
-            class="me-1 mb-1"
-          >
-            {{ keyword }}
-          </b-badge>
-          <span v-if="result.keywords.length > 5" class="text-muted">
-            +{{ result.keywords.length - 5 }} more
-          </span>
-        </div>
+    <div v-if="keywordList.length" class="keywords">
+      <div class="label">Keywords</div>
+      <div class="values">
+        <span
+          v-for="(kw, idx) in highlightedKeywords"
+          :key="idx"
+          class="keyword mx-2 text-secondary"
+          v-html="kw"
+        ></span>
       </div>
+    </div>
+    <div v-if="collectionNames != null">
+      in collections {{ collectionNames }}
+    </div>
+    <div class="badges mt-2">
+      <b-badge variant="data" class="mr-1">
+        <b-icon class="mr-1" icon="server"></b-icon>
+        {{ result.resourceType || "data" }}
+      </b-badge>
 
-      <div class="result-actions ms-3">
-        <b-dropdown
-          right
-          variant="outline-secondary"
-          size="sm"
-          toggle-class="text-decoration-none"
-          no-caret
+      <b-badge v-if="connectedTools" variant="tool" class="mr-1">
+        <b-icon class="mr-1" icon="tools"></b-icon>Connected Tools
+      </b-badge>
+      <b-spinner v-if="connectedTools === undefined" size="small" />
+
+      <span v-if="disurlList.length">
+        <b-badge
+          v-for="i in disurlList"
+          :key="i"
+          variant="light"
+          class="mr-1"
+          :href="i"
         >
-          <template #button-content>
-            <i class="fas fa-ellipsis-v"></i>
-          </template>
+          <a v-if="i.length > 0" class="card-link" target="_blank" rel="noopener">{{ i }}</a>
+        </b-badge>
+      </span>
+    </div>
 
-          <b-dropdown-item
-            :href="result.url"
-            target="_blank"
-            v-if="result.url"
-          >
-            <i class="fas fa-external-link-alt me-2"></i>
-            View Source
-          </b-dropdown-item>
-
-          <b-dropdown-item @click="$emit('add-to-collection', result)">
-            <i class="fas fa-plus me-2"></i>
-            Add to Collection
-          </b-dropdown-item>
-
-          <b-dropdown-item @click="shareResult(result)">
-            <i class="fas fa-share me-2"></i>
-            Share
-          </b-dropdown-item>
-        </b-dropdown>
-      </div>
+    <div class="badges mt-2 d-flex flex-wrap align-items-center">
+      <b-button
+        v-if="result.resourceType === 'data'"
+        variant="primary"
+        size="sm"
+        class="ml-auto"
+        @click.stop="saveItems('data')"
+        >Save Dataset</b-button
+      >
+      <b-button
+        v-else-if="result.resourceType === 'tool'"
+        variant="primary"
+        size="sm"
+        class="ml-auto"
+        @click.stop="saveItems('tool')"
+        >Save Tool</b-button
+      >
+      <b-button
+        v-else
+        variant="primary"
+        size="sm"
+        class="ml-auto"
+        @click.stop="saveItems(result.resourceType || 'other')"
+        >Save Other</b-button
+      >
     </div>
   </b-card>
 </template>
 
 <script>
+import _ from "lodash";
+import { isProxy, toRaw } from "vue";
+import { mapActions, mapGetters } from "vuex";
+import localforage from "localforage";
 import { normalizeDatasetGraphIri } from "@/utils/datasetIdentifiers.js";
 
 export default {
@@ -97,111 +99,268 @@ export default {
   props: {
     result: {
       type: Object,
-      required: true
+      required: true,
     },
     index: {
       type: Number,
-      default: 0
-    }
+      default: 0,
+    },
+    /** From Search2 / useSearch — used to bold active keyword facets (field `kw`). */
+    activeFilters: {
+      type: Object,
+      default: () => ({}),
+    },
+  },
+  data() {
+    return {
+      connectedTools: undefined,
+      clickToAddCollection: false,
+      collectionNames: undefined,
+    };
+  },
+  computed: {
+    ...mapGetters(["getConnectedTool"]),
+    resourceTypeLower() {
+      return String(this.result.resourceType || "data").toLowerCase();
+    },
+    displayName() {
+      return this.result.name || "Untitled";
+    },
+    resultLink() {
+      return this.buildResultLink(this.result);
+    },
+    keywordList() {
+      const k = this.result.keywords;
+      if (Array.isArray(k) && k.length) return k;
+      if (this.result.kw) {
+        if (Array.isArray(this.result.kw)) return this.result.kw;
+        return String(this.result.kw)
+          .split(",")
+          .map((s) => s.trim())
+          .filter(Boolean);
+      }
+      return [];
+    },
+    disurlList() {
+      const d = this.result.disurl;
+      if (!d) return [];
+      if (Array.isArray(d)) return d.filter((x) => x && String(x).length > 0);
+      return [String(d)].filter((x) => x.length > 0);
+    },
+    kwFacetSelection() {
+      const raw = this.activeFilters?.kw;
+      if (!raw) return [];
+      return Array.isArray(raw) ? raw : [raw];
+    },
+    highlightedKeywords() {
+      const filters = this.kwFacetSelection;
+      const keywords = this.keywordList;
+      if (!keywords.length) return [];
+      return keywords.map((kw) => {
+        if (_.includes(filters, kw)) {
+          return `<b>${_.escape(kw)}</b>`;
+        }
+        return _.escape(kw);
+      });
+    },
+  },
+  mounted() {
+    this.hasTool();
+    this.inCollection();
   },
   methods: {
-    getResultLink(result) {
-      const resourceType = result.resourceType || 'data';
+    ...mapActions(["hasConnectedTools"]),
+    storageKey() {
+      return this.result.g || this.result.subj || "";
+    },
+    inCollection() {
+      const key = this.storageKey();
+      if (!key) return;
+      const self = this;
+      localforage
+        .getItem(key, function (err, value) {
+          if (err != null || value === null) {
+            return;
+          }
+          if (value?.assignedCollections) {
+            self.collectionNames = value.assignedCollections;
+          }
+        })
+        .catch((error) => console.log(error));
+    },
+    saveItems(type) {
+      this.clickToAddCollection = true;
+      let item = this.result;
+      if (isProxy(this.result)) {
+        item = toRaw(this.result);
+      }
+      const key = item.g || item.subj;
+      if (!key) {
+        this.clickToAddCollection = false;
+        return;
+      }
+      localforage.getItem(key, (err, value) => {
+        if (value === null) {
+          localforage
+            .setItem(key, {
+              type,
+              collection: "unassigned",
+              value: item,
+            })
+            .then(() => {
+              console.log("store " + key + " to localstorage");
+            })
+            .catch((e) => {
+              console.log(e);
+            });
+        }
+      });
+    },
+    buildResultLink(result) {
+      const resourceType = result.resourceType || "data";
       const id = String(result.id || result.subj || "").trim();
-      if (!id) return { name: 'dataset', params: { d: '' } };
-      if (resourceType === 'tool') {
-        return { name: 'tool', params: { t: id } };
+      if (!id) return { name: "dataset", params: { d: "" } };
+      if (resourceType === "tool") {
+        return { name: "tool", params: { t: id } };
       }
       const gNorm = result.g
         ? normalizeDatasetGraphIri(result.g) ?? result.g
         : undefined;
       if (gNorm) {
         return {
-          name: 'dataset',
+          name: "dataset",
           params: { d: gNorm },
         };
       }
       return {
-        name: 'dataset',
+        name: "dataset",
         params: { d: id },
       };
     },
-    getResourceTypeVariant(resourceType) {
-      const variants = {
-        data: 'primary',
-        tool: 'success',
-        person: 'info',
-        researchProject: 'warning',
-        event: 'secondary'
-      };
-      return variants[resourceType] || 'primary';
-    },
-    truncateText(text, maxLength) {
-      if (!text || text.length <= maxLength) return text;
-      return text.substring(0, maxLength) + '...';
-    },
-    formatDate(dateString) {
-      // Fallback-safe formatting
-      try {
-        const d = new Date(dateString);
-        if (isNaN(d.getTime())) return dateString;
-        return d.toLocaleDateString();
-      } catch {
-        return dateString;
+    showDetails() {
+      if (this.clickToAddCollection) {
+        this.clickToAddCollection = false;
+        return;
       }
+      const rt = this.result.resourceType || "data";
+      if (rt !== "data" && rt !== "tool") {
+        this.makeToast(this.result.subj);
+        return;
+      }
+      this.$router.push(this.resultLink);
     },
-    async shareResult(result) {
-      const url = window.location.href;
-      if (navigator.share) {
-        try {
-          await navigator.share({
-            title: result.name || 'Result',
-            text: result.description || '',
-            url
-          });
-        } catch {
-          // ignore cancellation
-        }
+    makeToast(mesg = "Error") {
+      const message = `Unknown type. Send us this identifier ${mesg}`;
+      this.$bvToast.toast(message, {
+        title: "Cannot locate item",
+        autoHideDelay: 5000,
+        appendToast: false,
+      });
+    },
+    hasTool() {
+      const self = this;
+      const gg = self.result.g;
+      if (!gg) {
+        self.connectedTools = false;
+        return;
+      }
+      if (self.getConnectedTool(gg)) {
+        self.connectedTools = self.getConnectedTool(gg);
       } else {
-        try {
-          await navigator.clipboard.writeText(url);
-        } catch {
-          // ignore clipboard issues
-        }
+        self
+          .hasConnectedTools(gg)
+          .then(function (o) {
+            self.connectedTools = o;
+          })
+          .catch((err) => {
+            self.connectedTools = false;
+            console.info(err);
+          });
       }
-    }
-  }
+    },
+  },
 };
 </script>
 
-<style scoped>
-.result-item {
-  transition: box-shadow 0.2s ease;
+<style scoped lang="scss">
+@import "@/assets/bootstrapcss/custom";
+
+article.result-item-master {
+  cursor: pointer;
+  margin-top: 0.5em;
+
+  border: {
+    right: 0px;
+    left: 0px;
+  }
+  box-shadow: 0 0 10px 1px black;
+
+  &:hover {
+    background: {
+      color: $gray-300;
+    }
+  }
+
+  .card-body {
+    padding: ($spacer * 1.5) $spacer;
+  }
 }
-.result-item:hover {
-  box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+
+.keywords {
+  display: flex;
+
+  font: {
+    size: 80%;
+  }
+
+  .label {
+    font: {
+      weight: bold;
+    }
+    text: {
+      transform: uppercase;
+    }
+  }
+
+  .values {
+    display: flex;
+    white-space: nowrap;
+    flex-wrap: wrap;
+
+    .keyword {
+      padding: {
+        left: $spacer / 2;
+      }
+    }
+  }
 }
-.result-title {
-  font-size: 1.1rem;
-  margin-bottom: 0.5rem;
+
+.name {
+  color: $gray-800;
+
+  font: {
+    weight: 600;
+    size: 120%;
+  }
+  line: {
+    height: 120%;
+  }
 }
-.result-title a {
-  color: #0d6efd;
+
+.publisher {
+  color: $gray-500;
+
+  margin: {
+    top: -($spacer * 0.4);
+  }
+
+  font: {
+    style: italic;
+    size: 90%;
+  }
 }
-.result-title a:hover {
-  color: #0a58ca;
-}
-.result-description {
-  line-height: 1.4;
-  margin-bottom: 0.5rem;
-}
-.result-metadata {
-  margin-bottom: 0.5rem;
-}
-.result-keywords .badge {
-  font-size: 0.75em;
-}
-.result-actions {
-  flex-shrink: 0;
+
+.description {
+  color: $gray-500;
 }
 </style>

--- a/client/src/components/facetsearch/ResultItem2.vue
+++ b/client/src/components/facetsearch/ResultItem2.vue
@@ -20,11 +20,13 @@
       ><span v-html="result.description"></span></b-card-text
     >
 
-    <div v-if="keywordList.length" class="keywords">
-      <div class="label">Keywords</div>
+    <div v-if="result.kw" class="keywords">
+      <b-badge variant="primary" class="result-badge mr-2 flex-shrink-0">
+        Keywords
+      </b-badge>
       <div class="values">
         <span
-          v-for="(kw, idx) in highlightedKeywords"
+          v-for="(kw, idx) in highlightKw(activeFilters, result.kw)"
           :key="idx"
           class="keyword mx-2 text-secondary"
           v-html="kw"
@@ -35,12 +37,12 @@
       in collections {{ collectionNames }}
     </div>
     <div class="badges mt-2">
-      <b-badge variant="data" class="mr-1">
+      <b-badge variant="data" class="result-badge mr-1">
         <b-icon class="mr-1" icon="server"></b-icon>
         {{ result.resourceType || "data" }}
       </b-badge>
 
-      <b-badge v-if="connectedTools" variant="tool" class="mr-1">
+      <b-badge v-if="connectedTools" variant="tool" class="result-badge mr-1">
         <b-icon class="mr-1" icon="tools"></b-icon>Connected Tools
       </b-badge>
       <b-spinner v-if="connectedTools === undefined" size="small" />
@@ -75,6 +77,7 @@
         @click.stop="saveItems('tool')"
         >Save Tool</b-button
       >
+      <!-- Save Other — disabled for now; restore when non-data/tool save flow is ready
       <b-button
         v-else
         variant="primary"
@@ -83,6 +86,7 @@
         @click.stop="saveItems(result.resourceType || 'other')"
         >Save Other</b-button
       >
+      -->
     </div>
   </b-card>
 </template>
@@ -129,39 +133,11 @@ export default {
     resultLink() {
       return this.buildResultLink(this.result);
     },
-    keywordList() {
-      const k = this.result.keywords;
-      if (Array.isArray(k) && k.length) return k;
-      if (this.result.kw) {
-        if (Array.isArray(this.result.kw)) return this.result.kw;
-        return String(this.result.kw)
-          .split(",")
-          .map((s) => s.trim())
-          .filter(Boolean);
-      }
-      return [];
-    },
     disurlList() {
       const d = this.result.disurl;
       if (!d) return [];
       if (Array.isArray(d)) return d.filter((x) => x && String(x).length > 0);
       return [String(d)].filter((x) => x.length > 0);
-    },
-    kwFacetSelection() {
-      const raw = this.activeFilters?.kw;
-      if (!raw) return [];
-      return Array.isArray(raw) ? raw : [raw];
-    },
-    highlightedKeywords() {
-      const filters = this.kwFacetSelection;
-      const keywords = this.keywordList;
-      if (!keywords.length) return [];
-      return keywords.map((kw) => {
-        if (_.includes(filters, kw)) {
-          return `<b>${_.escape(kw)}</b>`;
-        }
-        return _.escape(kw);
-      });
     },
   },
   mounted() {
@@ -187,6 +163,22 @@ export default {
           }
         })
         .catch((error) => console.log(error));
+    },
+    highlightKw(filters, keywords) {
+      if (!keywords) return [];
+      const activeKw = filters?.kw;
+      if (Array.isArray(keywords)) {
+        return keywords.map((kw) => {
+          if (_.includes(activeKw, kw)) {
+            return `<b>${_.escape(kw)}</b>`;
+          }
+          return _.escape(kw);
+        });
+      }
+      if (_.includes(activeKw, keywords)) {
+        return [`<b>${_.escape(keywords)}</b>`];
+      }
+      return [_.escape(String(keywords))];
     },
     saveItems(type) {
       this.clickToAddCollection = true;
@@ -304,32 +296,39 @@ article.result-item-master {
   .card-body {
     padding: ($spacer * 1.5) $spacer;
   }
+
+  .badge {
+    font-size: 12px;
+    font-weight: 700;
+    line-height: 1;
+    padding: 0 8px;
+    height: 26px;
+    box-sizing: border-box;
+    display: inline-flex;
+    align-items: center;
+    white-space: nowrap;
+
+    .b-icon {
+      font-size: 12px;
+      line-height: 1;
+    }
+  }
 }
 
 .keywords {
   display: flex;
-
-  font: {
-    size: 80%;
-  }
-
-  .label {
-    font: {
-      weight: bold;
-    }
-    text: {
-      transform: uppercase;
-    }
-  }
+  align-items: flex-start;
 
   .values {
+    font: {
+      size: 80%;
+    }
     display: flex;
-    white-space: nowrap;
     flex-wrap: wrap;
 
     .keyword {
       padding: {
-        left: $spacer / 2;
+        left: 0;
       }
     }
   }

--- a/client/src/components/facetsearch/Results2.vue
+++ b/client/src/components/facetsearch/Results2.vue
@@ -20,6 +20,7 @@
         :key="result.id || result.subj || index"
         :result="result"
         :index="index"
+        :active-filters="activeFilters"
       />
     </div>
   </div>
@@ -43,6 +44,10 @@ export default {
     loading: {
       type: Boolean,
       default: false
+    },
+    activeFilters: {
+      type: Object,
+      default: () => ({})
     }
   }
 };

--- a/client/src/components/facetsearch/Search2.vue
+++ b/client/src/components/facetsearch/Search2.vue
@@ -85,6 +85,7 @@
           <Results2
             :results="results"
             :loading="isLoading"
+            :active-filters="activeFilters"
           />
         </b-col>
       </b-row>

--- a/client/src/components/facetsearch/Search2.vue
+++ b/client/src/components/facetsearch/Search2.vue
@@ -71,7 +71,7 @@
         <b-col md="9" class="results">
           <ResultHeader2
             :current-count="results.length"
-            :total-count="results.length"
+            :total-count="totalCount"
             :filters="activeFiltersDisplay"
             :loading="isLoading"
           />

--- a/client/src/components/facetsearch/Search2.vue
+++ b/client/src/components/facetsearch/Search2.vue
@@ -72,6 +72,7 @@
           <ResultHeader2
             :current-count="results.length"
             :total-count="totalCount"
+            :search-total-count="searchTotalCount"
             :filters="activeFiltersDisplay"
             :loading="isLoading"
           />

--- a/client/src/composables/useSearch.js
+++ b/client/src/composables/useSearch.js
@@ -153,12 +153,12 @@ export function useFacetOptions(searchService, field) {
   const loading = ref(false);
   const error = ref(null);
 
-  const loadOptions = async (currentFilters = {}) => {
+  const loadOptions = async (searchContext = {}) => {
     loading.value = true;
     error.value = null;
 
     try {
-      const facetOptions = await searchService.getFacetOptions(field, currentFilters);
+      const facetOptions = await searchService.getFacetOptions(field, searchContext);
       options.value = facetOptions;
     } catch (err) {
       error.value = err.message;
@@ -179,6 +179,9 @@ export function useFacetOptions(searchService, field) {
 export function useFacet(facetConfig, searchComposable) {
   const {
     activeFilters,
+    textQuery,
+    searchExactMatch,
+    resourceType,
     addFilter,
     removeFilter,
     setFilter,
@@ -230,13 +233,32 @@ export function useFacet(facetConfig, searchComposable) {
   const lastLoadedKey = ref('');
   let reloadTimer = null;
 
-  const loadOptionsForCurrentState = async () => {
+  const buildSearchContext = () => {
     const currentFilters = { ...activeFilters.value };
     delete currentFilters[field];
-    const key = filtersKey(currentFilters);
+    return {
+      filters: currentFilters,
+      textQuery: textQuery.value,
+      searchExactMatch: searchExactMatch.value,
+      resourceType: resourceType.value,
+    };
+  };
+
+  const optionsLoadKey = (context) => {
+    return JSON.stringify({
+      filters: filtersKey(context.filters),
+      textQuery: context.textQuery || '',
+      searchExactMatch: !!context.searchExactMatch,
+      resourceType: context.resourceType || '',
+    });
+  };
+
+  const loadOptionsForCurrentState = async () => {
+    const searchContext = buildSearchContext();
+    const key = optionsLoadKey(searchContext);
     if (key === lastLoadedKey.value) return;
     lastLoadedKey.value = key;
-    await loadOptions(currentFilters);
+    await loadOptions(searchContext);
   };
 
   const scheduleOptionsReload = () => {
@@ -247,15 +269,10 @@ export function useFacet(facetConfig, searchComposable) {
   };
 
   watch(
-    () => {
-      const otherFilters = { ...activeFilters.value };
-      delete otherFilters[field];
-      return otherFilters;
-    },
+    () => optionsLoadKey(buildSearchContext()),
     () => {
       scheduleOptionsReload();
-    },
-    { deep: true }
+    }
   );
 
   onMounted(() => {

--- a/client/src/composables/useSearch.js
+++ b/client/src/composables/useSearch.js
@@ -50,6 +50,7 @@ export function useSearch(configOrRef) {
 
   const isLoading = computed(() => state.isLoading);
   const results = computed(() => state.results);
+  const totalCount = computed(() => state.totalCount);
   const error = computed(() => state.error);
   const textQuery = computed({
     get: () => state.textQuery,
@@ -123,6 +124,7 @@ export function useSearch(configOrRef) {
   return {
     isLoading,
     results,
+    totalCount,
     error,
     textQuery,
     searchExactMatch,

--- a/client/src/composables/useSearch.js
+++ b/client/src/composables/useSearch.js
@@ -51,6 +51,7 @@ export function useSearch(configOrRef) {
   const isLoading = computed(() => state.isLoading);
   const results = computed(() => state.results);
   const totalCount = computed(() => state.totalCount);
+  const searchTotalCount = computed(() => state.searchTotalCount);
   const error = computed(() => state.error);
   const textQuery = computed({
     get: () => state.textQuery,
@@ -125,6 +126,7 @@ export function useSearch(configOrRef) {
     isLoading,
     results,
     totalCount,
+    searchTotalCount,
     error,
     textQuery,
     searchExactMatch,
@@ -152,19 +154,25 @@ export function useFacetOptions(searchService, field) {
   const options = ref([]);
   const loading = ref(false);
   const error = ref(null);
+  let loadGeneration = 0;
 
   const loadOptions = async (searchContext = {}) => {
+    const generation = ++loadGeneration;
     loading.value = true;
     error.value = null;
 
     try {
       const facetOptions = await searchService.getFacetOptions(field, searchContext);
+      if (generation !== loadGeneration) return;
       options.value = facetOptions;
     } catch (err) {
+      if (generation !== loadGeneration) return;
       error.value = err.message;
       console.error(`Error loading options for ${field}:`, err);
     } finally {
-      loading.value = false;
+      if (generation === loadGeneration) {
+        loading.value = false;
+      }
     }
   };
 
@@ -187,7 +195,8 @@ export function useFacet(facetConfig, searchComposable) {
     setFilter,
     clearFilter,
     isFilterActive,
-    searchService
+    searchService,
+    filterStateManager,
   } = searchComposable;
 
   const field = facetConfig.field;
@@ -253,30 +262,43 @@ export function useFacet(facetConfig, searchComposable) {
     });
   };
 
-  const loadOptionsForCurrentState = async () => {
+  const loadOptionsForCurrentState = async (force = false) => {
     const searchContext = buildSearchContext();
     const key = optionsLoadKey(searchContext);
-    if (key === lastLoadedKey.value) return;
+    if (!force && key === lastLoadedKey.value) return;
     lastLoadedKey.value = key;
     await loadOptions(searchContext);
   };
 
-  const scheduleOptionsReload = () => {
+  const scheduleOptionsReload = (force = false) => {
     if (reloadTimer) clearTimeout(reloadTimer);
     reloadTimer = setTimeout(() => {
-      void loadOptionsForCurrentState();
+      void loadOptionsForCurrentState(force);
     }, 120);
   };
 
   watch(
     () => optionsLoadKey(buildSearchContext()),
     () => {
-      scheduleOptionsReload();
+      scheduleOptionsReload(false);
+    }
+  );
+
+  // Reload facet counts after the main search finishes (avoids stale pre-search responses).
+  watch(
+    () => filterStateManager.state.lastQueryAt,
+    () => {
+      if (!filterStateManager.state.lastQuerySignature) return;
+      scheduleOptionsReload(true);
     }
   );
 
   onMounted(() => {
-    void loadOptionsForCurrentState();
+    const ctx = buildSearchContext();
+    const hasQuery = String(ctx.textQuery || '').trim() !== '';
+    const hasFilters = Object.keys(ctx.filters || {}).length > 0;
+    if (!hasQuery && !hasFilters) return;
+    void loadOptionsForCurrentState(false);
   });
 
   onBeforeUnmount(() => {

--- a/client/src/services/FilterStateManager.js
+++ b/client/src/services/FilterStateManager.js
@@ -14,6 +14,7 @@ export class FilterStateManager {
       isLoading: false,
       results: [],
       totalCount: 0,
+      searchTotalCount: 0,
       error: null,
       lastQuery: null,
       lastQuerySignature: '',
@@ -126,10 +127,19 @@ export class FilterStateManager {
     this.state.searchExactMatch = !!exact;
   }
 
+  hasActiveFacetFilters(filters) {
+    if (!filters || typeof filters !== 'object') return false;
+    return Object.keys(filters).some((key) => {
+      const value = filters[key];
+      return Array.isArray(value) ? value.length > 0 : !!value;
+    });
+  }
+
   async executeQuery() {
     if (!this.shouldExecuteQuery()) {
       this.state.results = [];
       this.state.totalCount = 0;
+      this.state.searchTotalCount = 0;
       return;
     }
 
@@ -145,6 +155,12 @@ export class FilterStateManager {
 
     this.state.isLoading = true;
     this.state.error = null;
+
+    const filtersActive = this.hasActiveFacetFilters(params.filters);
+    const prevHadFilters = this.hasActiveFacetFilters(this.state.lastQuery?.filters);
+    if (filtersActive && !prevHadFilters && this.state.totalCount > 0) {
+      this.state.searchTotalCount = this.state.totalCount;
+    }
 
     try {
       this.state.lastQuery = params;
@@ -164,6 +180,13 @@ export class FilterStateManager {
             this.state.totalCount = n;
           });
         }
+        if (outcome?.searchTotalCountPromise) {
+          outcome.searchTotalCountPromise.then((n) => {
+            this.state.searchTotalCount = n > 0 ? n : this.state.totalCount;
+          });
+        } else {
+          this.state.searchTotalCount = 0;
+        }
       }
 
     } catch (error) {
@@ -171,6 +194,7 @@ export class FilterStateManager {
       this.state.error = error.message || 'Query execution failed';
       this.state.results = [];
       this.state.totalCount = 0;
+      this.state.searchTotalCount = 0;
     } finally {
       this.state.isLoading = false;
     }

--- a/client/src/services/FilterStateManager.js
+++ b/client/src/services/FilterStateManager.js
@@ -13,6 +13,7 @@ export class FilterStateManager {
       activeFilters: {},
       isLoading: false,
       results: [],
+      totalCount: 0,
       error: null,
       lastQuery: null,
       lastQuerySignature: '',
@@ -128,6 +129,7 @@ export class FilterStateManager {
   async executeQuery() {
     if (!this.shouldExecuteQuery()) {
       this.state.results = [];
+      this.state.totalCount = 0;
       return;
     }
 
@@ -149,13 +151,26 @@ export class FilterStateManager {
       this.state.lastQuerySignature = signature;
       this.state.lastQueryAt = now;
 
-      const results = await this.queryExecutor(params);
-      this.state.results = results || [];
+      const outcome = await this.queryExecutor(params);
+      if (Array.isArray(outcome)) {
+        this.state.results = outcome;
+        this.state.totalCount = outcome.length;
+      } else {
+        this.state.results = outcome?.results || [];
+        this.state.totalCount =
+          outcome?.totalCount ?? this.state.results.length;
+        if (outcome?.totalCountPromise) {
+          outcome.totalCountPromise.then((n) => {
+            this.state.totalCount = n;
+          });
+        }
+      }
 
     } catch (error) {
       console.error('Query execution error:', error);
       this.state.error = error.message || 'Query execution failed';
       this.state.results = [];
+      this.state.totalCount = 0;
     } finally {
       this.state.isLoading = false;
     }

--- a/client/src/services/SearchService.js
+++ b/client/src/services/SearchService.js
@@ -223,11 +223,12 @@ export class SearchService {
   // -------------------------
 
   /**
-   * Fetch facet options (distinct values + counts) for a given field
-   * currentFilters: other active filters (excluding this field)
+   * Fetch facet options (distinct values + counts) for a given field.
+   * searchContext: { filters, textQuery, searchExactMatch, resourceType }
+   *   filters = other active facet filters (excluding this field)
    */
-  async getFacetOptions(field, currentFilters = {}) {
-    const query = this.buildFacetOptionsQuery(field, currentFilters);
+  async getFacetOptions(field, searchContext = {}) {
+    const query = this.buildFacetOptionsQuery(field, searchContext);
     const data = await this.sendToTriplestoreWithFallback(query);
     return this.processFacetOptions(data);
   }
@@ -235,7 +236,7 @@ export class SearchService {
   /**
    * Build a SPARQL query that returns distinct values and their counts for a facet
    */
-  buildFacetOptionsQuery(field, currentFilters) {
+  buildFacetOptionsQuery(field, searchContext = {}) {
     const facetConfig = (this.config.FACETS || []).find(f => f.field === field);
     if (!facetConfig) {
       return `
@@ -243,6 +244,13 @@ ${this.queryBuilder.buildPrefixes()}
 SELECT ?value (0 as ?count) WHERE { FILTER(false) } LIMIT 0
 `;
     }
+
+    const {
+      filters: currentFilters = {},
+      textQuery = '',
+      searchExactMatch = false,
+      resourceType = '',
+    } = searchContext;
 
     const sparqlProperty =
       facetConfig.sparql_property ||
@@ -252,28 +260,19 @@ SELECT ?value (0 as ?count) WHERE { FILTER(false) } LIMIT 0
     const filtersCopy = { ...(currentFilters || {}) };
     delete filtersCopy[field];
 
-    const needDepthOptional =
-      this.queryBuilder.filtersNeedDepthVariableMeasured(filtersCopy);
-
     let q = '';
     q += this.queryBuilder.buildPrefixes();
-    q += `SELECT DISTINCT ?value (COUNT(*) AS ?count)
+    q += `SELECT ?value (COUNT(DISTINCT ?subj) AS ?count)
 WHERE {
 `;
-    if (needDepthOptional) {
-      q += this.queryBuilder.buildOptionalDepthVariableMeasured();
-    }
-    q += this.queryBuilder.buildFilterFragments(filtersCopy, {
-      rangePlacement: needDepthOptional ? 'early' : 'all',
-    });
-    q += this.queryBuilder.buildBaseGraphPattern();
+    q += this.queryBuilder.buildFacetOptionsWhereInner(
+      textQuery,
+      searchExactMatch,
+      resourceType,
+      filtersCopy
+    );
     q += `  ?subj ${sparqlProperty} ?value .
 `;
-    if (needDepthOptional) {
-      q += this.queryBuilder.buildFilterFragments(filtersCopy, {
-        rangePlacement: 'late',
-      });
-    }
     q += `}
 GROUP BY ?value
 ORDER BY DESC(?count) ?value

--- a/client/src/services/SearchService.js
+++ b/client/src/services/SearchService.js
@@ -70,23 +70,47 @@ export class SearchService {
   /**
    * Execute a search with the current filters and parameters
    */
+  hasActiveFacetFilters(filters) {
+    if (!filters || typeof filters !== 'object') return false;
+    return Object.keys(filters).some((key) => {
+      const value = filters[key];
+      return Array.isArray(value) ? value.length > 0 : !!value;
+    });
+  }
+
   async executeQuery(searchParams) {
     try {
       const sparqlQuery = this.queryBuilder.buildQuery(searchParams);
       const response = await this.sendToTriplestoreWithFallback(sparqlQuery);
       const results = this.processResults(response);
 
-      const totalCountPromise = this.fetchTotalCount(searchParams)
+      const countDistinctSubjects = this.hasActiveFacetFilters(searchParams.filters);
+
+      const totalCountPromise = this.fetchTotalCount(searchParams, {
+        countDistinctSubjects,
+      })
         .then((n) => (n > 0 ? n : results.length))
         .catch((err) => {
           console.warn('Search count query failed:', err?.message || err);
           return results.length;
         });
 
+      let searchTotalCountPromise = null;
+      if (this.hasActiveFacetFilters(searchParams.filters)) {
+        searchTotalCountPromise = this.fetchTotalCount(
+          { ...searchParams, filters: {} },
+          { countDistinctSubjects: false }
+        ).catch((err) => {
+          console.warn('Search unfiltered count query failed:', err?.message || err);
+          return 0;
+        });
+      }
+
       return {
         results,
         totalCount: results.length,
         totalCountPromise,
+        searchTotalCountPromise,
       };
     } catch (error) {
       console.error('Search service error:', error);
@@ -94,8 +118,8 @@ export class SearchService {
     }
   }
 
-  async fetchTotalCount(searchParams) {
-    const countQuery = this.queryBuilder.buildCountQuery(searchParams);
+  async fetchTotalCount(searchParams, options = {}) {
+    const countQuery = this.queryBuilder.buildCountQuery(searchParams, options);
     const countResponse = await this.sendToTriplestoreWithFallback(countQuery);
     return this.processCountResult(countResponse);
   }

--- a/client/src/services/SearchService.js
+++ b/client/src/services/SearchService.js
@@ -18,6 +18,17 @@ export function datasetRouteIdFromBinding(row) {
   return subj || g || '';
 }
 
+/** Split SPARQL GROUP_CONCAT values the same way as state.js flattenSparqlResults. */
+export function splitSparqlGroupConcat(value) {
+  if (value == null || value === '') return null;
+  const regex = /,(?![^(]*\)) /;
+  const elements = String(value).split(regex);
+  if (elements.length === 1 && elements[0].trim() === '') {
+    return null;
+  }
+  return elements;
+}
+
 /**
  * Main Search Service (QLever-first)
  * - Builds SPARQL from active filters
@@ -63,11 +74,30 @@ export class SearchService {
     try {
       const sparqlQuery = this.queryBuilder.buildQuery(searchParams);
       const response = await this.sendToTriplestoreWithFallback(sparqlQuery);
-      return this.processResults(response);
+      const results = this.processResults(response);
+
+      const totalCountPromise = this.fetchTotalCount(searchParams)
+        .then((n) => (n > 0 ? n : results.length))
+        .catch((err) => {
+          console.warn('Search count query failed:', err?.message || err);
+          return results.length;
+        });
+
+      return {
+        results,
+        totalCount: results.length,
+        totalCountPromise,
+      };
     } catch (error) {
       console.error('Search service error:', error);
       throw error;
     }
+  }
+
+  async fetchTotalCount(searchParams) {
+    const countQuery = this.queryBuilder.buildCountQuery(searchParams);
+    const countResponse = await this.sendToTriplestoreWithFallback(countQuery);
+    return this.processCountResult(countResponse);
   }
 
   /**
@@ -155,6 +185,12 @@ export class SearchService {
   /**
    * Normalize SPARQL JSON results to a flat array of objects
    */
+  processCountResult(response) {
+    const raw = response?.results?.bindings?.[0]?.count?.value;
+    const n = parseInt(raw ?? '0', 10);
+    return Number.isNaN(n) ? 0 : n;
+  }
+
   processResults(response) {
     if (!response || !response.results || !response.results.bindings) {
       return [];
@@ -168,8 +204,16 @@ export class SearchService {
       }
       // Convenience fields used by UI (dataset links use graph URN when available)
       out.id = datasetRouteIdFromBinding(out);
-      out.keywords = out.kwu ? out.kwu.split(',').map(k => k.trim()) : [];
       out.resourceType = out.resourceType_u;
+      if (out.kw !== undefined) {
+        out.kw = splitSparqlGroupConcat(out.kw);
+      }
+      if (out.placenames !== undefined) {
+        out.placenames = splitSparqlGroupConcat(out.placenames);
+      }
+      if (out.disurl !== undefined) {
+        out.disurl = splitSparqlGroupConcat(out.disurl);
+      }
       return out;
     });
   }

--- a/client/src/services/SparqlQueryBuilder.js
+++ b/client/src/services/SparqlQueryBuilder.js
@@ -54,9 +54,16 @@ export class SparqlQueryBuilder {
     return query;
   }
 
-  /** Total matching result rows (without LIMIT). Uses a lighter WHERE when card metadata is not needed for filters. */
-  buildCountQuery(searchParams) {
+  /**
+   * Total matches for the current search (without LIMIT).
+   * @param {object} searchParams
+   * @param {{ countDistinctSubjects?: boolean }} [options]
+   *   - countDistinctSubjects false (default): distinct result rows (?g ?subj ?name ?description ?type), matches pre-filter search total
+   *   - countDistinctSubjects true: distinct datasets (?subj), matches facet sidebar counts
+   */
+  buildCountQuery(searchParams, options = {}) {
     const { textQuery, searchExactMatch, resourceType, filters } = searchParams;
+    const countDistinctSubjects = options.countDistinctSubjects === true;
     const needsCardMetadata = this.filtersNeedCardMetadata(filters);
     const whereClause = this.buildWhereClause(
       textQuery,
@@ -66,14 +73,18 @@ export class SparqlQueryBuilder {
       { skipCardMetadata: !needsCardMetadata }
     );
     const innerWhere = whereClause.slice('WHERE {\n'.length, -'\n}\n'.length);
-    const groupKeys = needsCardMetadata
-      ? '?g ?subj ?name ?description ?type ?pubname ?placename ?datep ?temporalCoverage'
-      : '?g ?subj ?name ?description ?type';
 
     let query = this.buildPrefixes();
+    if (countDistinctSubjects) {
+      query += 'SELECT (COUNT(DISTINCT ?subj) AS ?count) WHERE {\n';
+      query += innerWhere;
+      query += '}\n';
+      return query;
+    }
+
     query += 'SELECT (COUNT(*) AS ?count) WHERE {\n';
     query += '  {\n';
-    query += `    SELECT DISTINCT ${groupKeys}\n`;
+    query += '    SELECT DISTINCT ?g ?subj ?name ?description ?type\n';
     query += '    WHERE {\n';
     query += innerWhere;
     query += '    }\n';

--- a/client/src/services/SparqlQueryBuilder.js
+++ b/client/src/services/SparqlQueryBuilder.js
@@ -204,7 +204,6 @@ export class SparqlQueryBuilder {
     }
     // Range filters use ?temporalCoverage (OPTIONAL), ?datep (BIND), ?maxDepth/?minDepth (depth OPTIONAL); must run after those bind.
     whereClause += this.buildFilterFragments(filters, { rangePlacement: 'late' });
-    whereClause += this.buildFilterFragments(filters, { rangePlacement: 'late' });
 
     whereClause += '}\n';
     return whereClause;

--- a/client/src/services/SparqlQueryBuilder.js
+++ b/client/src/services/SparqlQueryBuilder.js
@@ -185,6 +185,24 @@ export class SparqlQueryBuilder {
     return whereClause;
   }
 
+  /** Inner WHERE body for facet option counts (search text + filters, no card OPTIONALs unless needed). */
+  buildFacetOptionsWhereInner(textQuery, searchExactMatch, resourceType, filters) {
+    const needsCardMetadata = this.filtersNeedCardMetadata(filters);
+    const whereClause = this.buildWhereClause(
+      textQuery,
+      searchExactMatch,
+      resourceType,
+      filters,
+      { skipCardMetadata: !needsCardMetadata }
+    );
+    const prefix = 'WHERE {\n';
+    const suffix = '\n}\n';
+    if (!whereClause.startsWith(prefix) || !whereClause.endsWith(suffix)) {
+      return whereClause;
+    }
+    return whereClause.slice(prefix.length, -suffix.length);
+  }
+
   /** Dataset type for ?subj (outside GRAPH), matches QLever sparql_query.rq */
   buildSubjDatasetHead() {
     return `  VALUES ?sosType {

--- a/client/src/services/SparqlQueryBuilder.js
+++ b/client/src/services/SparqlQueryBuilder.js
@@ -54,6 +54,45 @@ export class SparqlQueryBuilder {
     return query;
   }
 
+  /** Total matching result rows (without LIMIT). Uses a lighter WHERE when card metadata is not needed for filters. */
+  buildCountQuery(searchParams) {
+    const { textQuery, searchExactMatch, resourceType, filters } = searchParams;
+    const needsCardMetadata = this.filtersNeedCardMetadata(filters);
+    const whereClause = this.buildWhereClause(
+      textQuery,
+      searchExactMatch,
+      resourceType,
+      filters,
+      { skipCardMetadata: !needsCardMetadata }
+    );
+    const innerWhere = whereClause.slice('WHERE {\n'.length, -'\n}\n'.length);
+    const groupKeys = needsCardMetadata
+      ? '?g ?subj ?name ?description ?type ?pubname ?placename ?datep ?temporalCoverage'
+      : '?g ?subj ?name ?description ?type';
+
+    let query = this.buildPrefixes();
+    query += 'SELECT (COUNT(*) AS ?count) WHERE {\n';
+    query += '  {\n';
+    query += `    SELECT DISTINCT ${groupKeys}\n`;
+    query += '    WHERE {\n';
+    query += innerWhere;
+    query += '    }\n';
+    query += '  }\n';
+    query += '}\n';
+    return query;
+  }
+
+  /** True when active filters require OPTIONAL card fields (keywords, publisher, ranges, etc.). */
+  filtersNeedCardMetadata(filters) {
+    if (!filters || typeof filters !== 'object') return false;
+    return Object.keys(filters).some((field) => {
+      const cfg = this.getFacetConfig(field);
+      if (!cfg) return false;
+      if (cfg.type === 'geo') return false;
+      return true;
+    });
+  }
+
   buildPrefixes() {
     return Object.entries(this.prefixes)
       .map(([prefix, uri]) => `PREFIX ${prefix}: ${uri}`)
@@ -70,21 +109,22 @@ export class SparqlQueryBuilder {
   buildSelectClause() {
     const selectVars = [
       '?g',
-      '?subj', '?name', '?description', '?url', '?datep',
+      '?subj', '?name', '?description', '?datep',
       '?pubname',
      // '?maxDepth', '?minDepth',
         '?temporalCoverage'
     ];
       const aggVars = {
-          'disurl':'url',
-           'placenames':'placename', 'kw':'kw_u', 'resourceType':'resourceType_u',
+          'disurl':'url1',
+           'placenames':'placename', 'kw':'kwu', 'resourceType':'resourceType_u',
       };
       const aggClause = this.buildSelectAggregateClause(aggVars);
 
     return `SELECT DISTINCT ${selectVars.join(' ')} ${aggClause.join(' ')} \n`;
   }
 
-  buildWhereClause(textQuery, searchExactMatch, resourceType, filters) {
+  buildWhereClause(textQuery, searchExactMatch, resourceType, filters, options = {}) {
+    const skipCardMetadata = options.skipCardMetadata === true;
     let whereClause = 'WHERE {\n';
 
     // QLever full-text must follow public/queries/qlever/sparql_query.rq: constrain ?subj as
@@ -102,8 +142,10 @@ export class SparqlQueryBuilder {
         resourceType,
         filters
       );
-      whereClause += this.buildOptionalProperties();
-      whereClause += this.buildBindings();
+      if (!skipCardMetadata) {
+        whereClause += this.buildOptionalProperties();
+        whereClause += this.buildBindings();
+      }
       whereClause += this.buildFilterFragments(filters, {
         rangePlacement: 'late',
         skipRangedepth: true,
@@ -127,11 +169,15 @@ export class SparqlQueryBuilder {
       whereClause += this.buildResourceTypeConstraints(resourceType);
     }
 
-    whereClause += this.buildOptionalProperties();
-    if (this.filtersNeedDepthVariableMeasured(filters)) {
+    if (!skipCardMetadata) {
+      whereClause += this.buildOptionalProperties();
+      if (this.filtersNeedDepthVariableMeasured(filters)) {
+        whereClause += this.buildOptionalDepthVariableMeasured();
+      }
+      whereClause += this.buildBindings();
+    } else if (this.filtersNeedDepthVariableMeasured(filters)) {
       whereClause += this.buildOptionalDepthVariableMeasured();
     }
-    whereClause += this.buildBindings();
     // Range filters use ?temporalCoverage (OPTIONAL), ?datep (BIND), ?maxDepth/?minDepth (depth OPTIONAL); must run after those bind.
     whereClause += this.buildFilterFragments(filters, { rangePlacement: 'late' });
 
@@ -483,7 +529,7 @@ ${inner}
     return '';
   }
     buildGroupbyClause(_limit, _offset) {
-        return `GROUP BY ?g ?subj  ?placename  ?datep ?pubname ?url  ?name ?description ?type  ?temporalCoverage ?kw  ?resourceType\n`;
+        return `GROUP BY ?g ?subj ?name ?description ?type ?pubname ?placename ?datep ?temporalCoverage\n`;
     }
   buildLimitClause(limit, offset) {
     return `LIMIT ${limit}\nOFFSET ${offset}\n`;

--- a/client/src/services/SparqlQueryBuilder.js
+++ b/client/src/services/SparqlQueryBuilder.js
@@ -168,8 +168,10 @@ export class SparqlQueryBuilder {
         filters
       );
       whereClause += this.buildConstraintRangeFragments(filters);
-      whereClause += this.buildOptionalProperties();
-      whereClause += this.buildBindings();
+      if (!skipCardMetadata) {
+        whereClause += this.buildOptionalProperties();
+        whereClause += this.buildBindings();
+      }
       whereClause += this.buildFilterFragments(filters, { rangePlacement: 'late' });
       whereClause += '}\n';
       return whereClause;


### PR DESCRIPTION
## Summary
- Align Search2 result cards with master-style layout: keywords on cards, publisher/description, dataset links
- Fix keyword SPARQL/parsing so `kw` values render on result cards
- Show **“Showing X of Y results”** in the results header (async total count)
- Unify card badge sizing/colors (Keywords, data, Connected Tools); top-align Keywords badge when values wrap
- Scope sidebar facet counts to the **active search query** (e.g. `Occurrence (29)` within “Northern Pacific”, not global catalog totals)
- Disable Spatial Filter in `config_qlever_and_or.yaml` (comment out `spatialCoverage` facet)

## Test plan
- [ ] Search `Northern Pacific` with `config_qlever_and_or.yaml` — cards show keywords, badges, and **Showing 100 of 102 results**
- [ ] Sidebar keyword counts reflect the search (not global totals like `86960`)
- [ ] Spatial Filter section is hidden
- [ ] Multi-line keywords keep the Keywords badge top-aligned
- [ ] Facet checkbox filters still narrow results correctly