### PR TITLE
Reformat Search2 facets and add AND/OR search tips popover

### DIFF
--- a/client/.env.production
+++ b/client/.env.production
@@ -1,5 +1,5 @@
 NODE_ENV=production
 VITE_APP_MAPBOX_API_KEY=
-VITE_APP_FACETS_CONFIG_FILE=config/config.yaml
+VITE_APP_FACETS_CONFIG_FILE=config/config_qlever_and_or.yaml
 #NODE_OPTIONS=--openssl-legacy-provider
 VITE_APP_TITLE=GeoCodes

--- a/client/public/config/config.yaml
+++ b/client/public/config/config.yaml
@@ -105,8 +105,8 @@ FACETS:
     sort: acs
     open: false
     type: text
-  - field: datep
-    title: Year Published Range
+  - field: temporalCoverage
+    title: Temporal Coverage
     sort: acs
     open: true
     type: rangeyear
@@ -118,8 +118,8 @@ FACETS:
     sort: acs
     open: true
     type: rangedepth
-  - field: temporalCoverage
-    title: Temporal Coverage
+  - field: datep
+    title: Year Published Range
     sort: acs
     open: true
     type: rangeyear

--- a/client/public/config/config_qlever_and_or.yaml
+++ b/client/public/config/config_qlever_and_or.yaml
@@ -105,8 +105,8 @@ FACETS:
     sort: acs
     open: false
     type: text
-  - field: datep
-    title: Year Published Range
+  - field: temporalCoverage
+    title: Temporal Coverage
     sort: acs
     open: true
     type: rangeyear
@@ -118,8 +118,8 @@ FACETS:
     sort: acs
     open: true
     type: rangedepth
-  - field: temporalCoverage
-    title: Temporal Coverage
+  - field: datep
+    title: Year Published Range
     sort: acs
     open: true
     type: rangeyear

--- a/client/src/components/facetsearch/FacetText2.vue
+++ b/client/src/components/facetsearch/FacetText2.vue
@@ -110,8 +110,6 @@
 import { ref, computed, inject } from 'vue';
 import { useFacet } from '@/composables/useSearch.js';
 
-const SORTABLE_FACET_FIELDS = ['kw'];
-
 export default {
   name: "FacetText2",
 
@@ -134,8 +132,10 @@ export default {
     const isOpen = ref(props.facetConfig.open !== false);
     const optionSortMode = ref('count');
 
+    const sortableFacetFields = ['kw', 'placenames'];
+
     const supportsOptionSort = computed(() =>
-      SORTABLE_FACET_FIELDS.includes(props.facetConfig.field)
+      sortableFacetFields.includes(props.facetConfig.field)
     );
 
     const sortedOptions = computed(() => {

--- a/client/src/components/facetsearch/FacetText2.vue
+++ b/client/src/components/facetsearch/FacetText2.vue
@@ -10,60 +10,82 @@
       </h6>
     </div>
 
-    <b-collapse :visible="isOpen">
-      <div class="facet-body">
-        <!-- Loading State -->
-        <div v-if="optionsLoading" class="text-center py-2">
+    <div v-show="isOpen" class="facet-body">
+        <!-- Loading State (only when no options yet) -->
+        <div v-if="optionsLoading && options.length === 0" class="text-center py-2">
           <b-spinner small></b-spinner>
           <small class="text-muted ms-2">Loading options...</small>
         </div>
 
-        <!-- Options -->
-        <div v-else-if="options.length > 0" class="facet-options">
-          <div
-            v-for="option in displayedOptions"
-            :key="option.value"
-            class="form-check"
-          >
-            <input
-              :id="`${field}-${option.value}`"
-              type="checkbox"
-              class="form-check-input"
-              :checked="isValueActive(option.value)"
-              @change="toggleValue(option.value)"
-            />
-            <label
-              :for="`${field}-${option.value}`"
-              class="form-check-label"
-            >
-              {{ option.label }}
-              <span class="text-muted">({{ option.count }})</span>
-            </label>
+        <template v-else-if="options.length > 0">
+          <div v-if="supportsOptionSort" class="facet-sort mb-2">
+            <span class="facet-sort-label">Sort:</span>
+            <div class="facet-sort-toggle" role="group" aria-label="Sort facet options">
+              <button
+                type="button"
+                class="facet-sort-btn"
+                :class="{ active: optionSortMode === 'count' }"
+                @click.stop="setOptionSortMode('count')"
+              >
+                Count
+              </button>
+              <button
+                type="button"
+                class="facet-sort-btn"
+                :class="{ active: optionSortMode === 'alpha' }"
+                @click.stop="setOptionSortMode('alpha')"
+              >
+                A–Z
+              </button>
+            </div>
           </div>
 
-          <!-- Show More/Less -->
-          <div v-if="options.length > 5" class="mt-2">
-            <b-button
-              v-if="!showAll"
-              variant="link"
-              size="sm"
-              class="p-0"
-              @click="showAll = true"
+          <div class="facet-options">
+            <div
+              v-for="option in displayedOptions"
+              :key="option.value"
+              class="form-check"
             >
-              Show {{ options.length - 5 }} more...
-            </b-button>
+              <input
+                :id="`${field}-${option.value}`"
+                type="checkbox"
+                class="form-check-input"
+                :checked="isValueActive(option.value)"
+                @change="toggleValue(option.value)"
+              />
+              <label
+                :for="`${field}-${option.value}`"
+                class="form-check-label"
+              >
+                {{ option.label }}
+                <span class="text-muted">({{ option.count }})</span>
+              </label>
+            </div>
 
-            <b-button
-              v-else
-              variant="link"
-              size="sm"
-              class="p-0"
-              @click="showAll = false"
-            >
-              Show less
-            </b-button>
+            <!-- Show More/Less -->
+            <div v-if="sortedOptions.length > 5" class="mt-2">
+              <b-button
+                v-if="!showAll"
+                variant="link"
+                size="sm"
+                class="p-0"
+                @click="showAll = true"
+              >
+                Show {{ sortedOptions.length - 5 }} more...
+              </b-button>
+
+              <b-button
+                v-else
+                variant="link"
+                size="sm"
+                class="p-0"
+                @click="showAll = false"
+              >
+                Show less
+              </b-button>
+            </div>
           </div>
-        </div>
+        </template>
 
         <!-- No Options -->
         <div v-else class="text-muted">
@@ -80,14 +102,15 @@
             Clear
           </b-button>
         </div>
-      </div>
-    </b-collapse>
+    </div>
   </div>
 </template>
 
 <script>
 import { ref, computed, inject } from 'vue';
 import { useFacet } from '@/composables/useSearch.js';
+
+const SORTABLE_FACET_FIELDS = ['kw'];
 
 export default {
   name: "FacetText2",
@@ -109,13 +132,37 @@ export default {
     // Local state
     const showAll = ref(false);
     const isOpen = ref(props.facetConfig.open !== false);
+    const optionSortMode = ref('count');
+
+    const supportsOptionSort = computed(() =>
+      SORTABLE_FACET_FIELDS.includes(props.facetConfig.field)
+    );
+
+    const sortedOptions = computed(() => {
+      const opts = facet.options.value;
+      if (!opts?.length) return [];
+
+      const compareAlpha = (a, b) =>
+        a.label.localeCompare(b.label, undefined, { sensitivity: 'base' });
+      const compareCount = (a, b) => {
+        if (b.count !== a.count) return b.count - a.count;
+        return compareAlpha(a, b);
+      };
+
+      const compare = optionSortMode.value === 'alpha' ? compareAlpha : compareCount;
+      return [...opts].sort(compare);
+    });
+
+    const setOptionSortMode = (mode) => {
+      optionSortMode.value = mode;
+    };
 
     // Computed
     const displayedOptions = computed(() => {
-      if (showAll.value || facet.options.value.length <= 5) {
-        return facet.options.value;
+      if (showAll.value || sortedOptions.value.length <= 5) {
+        return sortedOptions.value;
       }
-      return facet.options.value.slice(0, 5);
+      return sortedOptions.value.slice(0, 5);
     });
 
     const toggleOpen = () => {
@@ -126,6 +173,10 @@ export default {
       ...facet,
       showAll,
       isOpen,
+      supportsOptionSort,
+      optionSortMode,
+      setOptionSortMode,
+      sortedOptions,
       displayedOptions,
       toggleOpen
     };
@@ -159,6 +210,52 @@ export default {
 
 .facet-body {
   padding: 0.75rem;
+}
+
+.facet-sort {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.facet-sort-label {
+  font-size: 0.8rem;
+  color: #6c757d;
+  white-space: nowrap;
+}
+
+.facet-sort-toggle {
+  display: inline-flex;
+  border: 1px solid #ced4da;
+  border-radius: 0.25rem;
+  overflow: hidden;
+}
+
+.facet-sort-btn {
+  border: none;
+  background: #fff;
+  color: #495057;
+  font-size: 0.8rem;
+  padding: 0.2rem 0.55rem;
+  line-height: 1.4;
+  cursor: pointer;
+}
+
+.facet-sort-btn + .facet-sort-btn {
+  border-left: 1px solid #ced4da;
+}
+
+.facet-sort-btn:hover {
+  background: #f8f9fa;
+}
+
+.facet-sort-btn.active {
+  background: #0d6efd;
+  color: #fff;
+}
+
+.facet-sort-btn.active:hover {
+  background: #0b5ed7;
 }
 
 .facet-options {

--- a/client/src/components/facetsearch/Search2.vue
+++ b/client/src/components/facetsearch/Search2.vue
@@ -57,7 +57,11 @@
           </div>
 
           <!-- Dynamic Facets -->
-          <Facets2 :facets="facets" />
+          <Facets2 :facets="primaryFacets" />
+
+          <div v-if="resourceTypeFacet" class="mb-3">
+            <FacetText2 :facet-config="resourceTypeFacet" />
+          </div>
 
           <!-- Feedback Component -->
           <feedback
@@ -95,11 +99,12 @@
 </template>
 
 <script>
-import { onMounted, provide, watch } from 'vue';
+import { onMounted, provide, watch, computed } from 'vue';
 import { useRoute } from 'vue-router';
 import { useSearch } from '@/composables/useSearch.js';
 import { useConfig } from '@/composables/useConfig.js';
 import Facets2 from './Facets2.vue';
+import FacetText2 from './FacetText2.vue';
 import ResultHeader2 from './ResultHeader2.vue';
 import Results2 from './Results2.vue';
 import feedback from '@/components/feedback/feedback.vue';
@@ -109,6 +114,7 @@ export default {
 
   components: {
     Facets2,
+    FacetText2,
     ResultHeader2,
     Results2,
     feedback,
@@ -119,6 +125,14 @@ export default {
     const { config, facets } = useConfig();
 
     const search = useSearch(config);
+
+    const resourceTypeFacet = computed(() =>
+      (facets.value || []).find((f) => f.field === 'resourceType')
+    );
+
+    const primaryFacets = computed(() =>
+      (facets.value || []).filter((f) => f.field !== 'resourceType')
+    );
 
     provide('searchComposable', search);
 
@@ -139,7 +153,8 @@ export default {
 
     return {
       ...search,
-      facets
+      resourceTypeFacet,
+      primaryFacets,
     };
   }
 };

--- a/client/src/components/landing/landing.vue
+++ b/client/src/components/landing/landing.vue
@@ -35,6 +35,23 @@
                   d="M11.742 10.344a6.5 6.5 0 1 0-1.397 1.398h-.001q.044.06.098.115l3.85 3.85a1 1 0 0 0 1.415-1.414l-3.85-3.85a1 1 0 0 0-.115-.1zM12 6.5a5.5 5.5 0 1 1-11 0 5.5 5.5 0 0 1 11 0"
                 /></svg
             ></b-button>
+            <b-button id="search-info-btn" variant="outline-secondary" type="button" class="mr-2">
+              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-info-circle" viewBox="0 0 16 16">
+                <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14m0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16"/>
+                <path d="m8.93 6.588-2.29.287-.082.38.45.083c.294.07.352.176.288.469l-.738 3.468c-.194.897.105 1.319.808 1.319.545 0 1.178-.252 1.465-.598l.088-.416c-.2.176-.492.246-.686.246-.275 0-.375-.193-.304-.533zM9 4.5a1 1 0 1 1-2 0 1 1 0 0 1 2 0"/>
+              </svg>
+            </b-button>
+            <b-popover target="search-info-btn" triggers="click blur" placement="bottom" title="Search Tips">
+              <div>
+                <p><strong>AND search (default):</strong> Multiple words are all required.<br/>
+                <em>Example:</em> <code>water chemistry</code> → results must contain both words.</p>
+                <p><strong>OR search:</strong> Use <code> or </code> (lowercase, with spaces) between terms.<br/>
+                <em>Example:</em> <code>Atlantic or Pacific</code> → results containing either term.</p>
+                <p><strong>Combined:</strong> <code>sediment North Atlantic or North Pacific</code><br/>
+                → must contain "sediment" AND ("North Atlantic" OR "North Pacific").</p>
+                <p class="mb-0"><strong>Exact match checkbox:</strong> When unchecked, each word becomes a separate OR branch instead of requiring all words.</p>
+              </div>
+            </b-popover>
           </b-input-group-append>
         </b-input-group>
 


### PR DESCRIPTION
## Description

### Summary
- Add compact `Count | A–Z` sort toggles for text facet options in Search2, and enable them for:
  - `Keywords`
  - `Place`
- Move the `Resource Type` facet to the bottom of the sidebar, directly above the `Feedback` button.
- Swap the order of `Temporal Coverage` and `Year Published Range` in facet config so they render in the new order.
- Add an info icon on the landing page search input with a popover explaining:
  - default AND behavior
  - explicit `or` syntax
  - combined query examples
  - exact match checkbox behavior
- Align production facet config env to use `config_qlever_and_or.yaml`.

### Files changed
- `client/src/components/facetsearch/FacetText2.vue`
- `client/src/components/facetsearch/Search2.vue`
- `client/src/components/landing/landing.vue`
- `client/public/config/config.yaml`
- `client/public/config/config_qlever_and_or.yaml`
- `client/.env.production`

### Test plan
- [ ] Open Search2 and verify `Keywords` has `Count | A–Z` toggle and switches ordering correctly.
- [ ] Verify `Place` has the same `Count | A–Z` toggle and switches ordering correctly.
- [ ] Confirm `Resource Type` appears right above `Feedback`.
- [ ] Confirm `Temporal Coverage` appears before `Year Published Range`.
- [ ] Open landing page, click info icon, and verify AND/OR guidance content appears and closes correctly.
- [ ] Run lint/build checks as needed for client changes.