### PR TITLE
Add Search2 pagination and enable browse-all results for empty keyword

### DIFF
--- a/client/.env.example
+++ b/client/.env.example
@@ -1,5 +1,5 @@
 NODE_ENV=production
 VUE_APP_MAPBOX_API_KEY=
-VITE_APP_FACETS_CONFIG_FILE=config/config_dev.yaml
+VITE_APP_FACETS_CONFIG_FILE=config/config_qlever_and_or.yaml
 # Set to true to skip landing page fetch of report_stats.json (stops console 403 if OSS is private).
 # VITE_SKIP_LANDING_REPORT_STATS=true

--- a/client/src/components/facetsearch/ResultHeader2.vue
+++ b/client/src/components/facetsearch/ResultHeader2.vue
@@ -1,19 +1,19 @@
 <template>
   <div class="result-header mb-3">
-    <div class="d-flex justify-content-between align-items-center">
+    <div class="d-flex justify-content-between align-items-center flex-wrap gap-2">
       <div class="result-count">
         <h5 class="mb-1">
           <span v-if="loading">
             <b-spinner small class="me-2"></b-spinner>
             Searching...
           </span>
+          <span v-else-if="totalCount > 0">
+            Showing {{ displayStart.toLocaleString() }}-{{ displayEnd.toLocaleString() }} of
+            {{ totalCount.toLocaleString() }} results
+          </span>
           <span v-else-if="hasFilters && searchTotalCount > totalCount">
             Showing {{ totalCount.toLocaleString() }} of
             {{ searchTotalCount.toLocaleString() }} results
-          </span>
-          <span v-else-if="totalCount > currentCount">
-            Showing {{ currentCount.toLocaleString() }} of
-            {{ totalCount.toLocaleString() }} results
           </span>
           <span v-else>
             {{ resultLabelCount.toLocaleString() }}
@@ -35,12 +35,31 @@
       <!-- Sort Options -->
       <div class="sort-controls">
         <b-form-select
+          :value="currentPageSize"
+          :options="pageSizeOptionsFormatted"
+          size="sm"
+          class="page-size-select me-2"
+          @input="onPageSizeChange"
+        />
+        <b-form-select
           v-model="selectedSort"
           :options="sortOptions"
           size="sm"
           class="sort-select"
         />
       </div>
+    </div>
+
+    <div v-if="totalPages > 1" class="pagination-row mt-2">
+      <b-pagination
+        :value="currentPage"
+        :total-rows="totalCount"
+        :per-page="currentPageSize"
+        :limit="7"
+        align="center"
+        size="sm"
+        @input="onPageChange"
+      />
     </div>
   </div>
 </template>
@@ -51,6 +70,7 @@ import { useConfig } from '@/composables/useConfig.js';
 
 export default {
   name: "ResultHeader2",
+  emits: ['page-change', 'page-size-change'],
 
   props: {
     currentCount: {
@@ -72,6 +92,18 @@ export default {
     loading: {
       type: Boolean,
       default: false
+    },
+    currentPage: {
+      type: Number,
+      default: 1
+    },
+    currentPageSize: {
+      type: Number,
+      default: 10
+    },
+    pageSizeOptions: {
+      type: Array,
+      default: () => [10, 50, 100]
     }
   },
 
@@ -81,7 +113,7 @@ export default {
     },
   },
 
-  setup(props) {
+  setup(props, { emit }) {
     inject('searchComposable');
     const { config, getFacetConfig } = useConfig();
 
@@ -101,19 +133,57 @@ export default {
       }));
     });
 
+    const displayStart = computed(() => {
+      if (props.totalCount <= 0) return 0;
+      return (props.currentPage - 1) * props.currentPageSize + 1;
+    });
+
+    const displayEnd = computed(() => {
+      if (props.totalCount <= 0) return 0;
+      return Math.min(props.totalCount, props.currentPage * props.currentPageSize);
+    });
+
+    const totalPages = computed(() => {
+      if (props.currentPageSize <= 0) return 1;
+      return Math.max(1, Math.ceil(props.totalCount / props.currentPageSize));
+    });
+
+    const pageSizeOptionsFormatted = computed(() =>
+      (props.pageSizeOptions || []).map((size) => ({
+        value: Number(size),
+        text: `${Number(size)} / page`,
+      }))
+    );
+
     // Methods
     const getFieldDisplayName = (field) => {
       const facetConfig = getFacetConfig(field);
       return facetConfig?.title || field;
     };
 
+    const onPageChange = (page) => {
+      if (!Number.isFinite(Number(page))) return;
+      emit('page-change', Number(page));
+    };
+
+    const onPageSizeChange = (size) => {
+      if (!Number.isFinite(Number(size))) return;
+      emit('page-size-change', Number(size));
+    };
+
     return {
       selectedSort,
       hasFilters,
       sortOptions,
-      getFieldDisplayName
+      getFieldDisplayName,
+      displayStart,
+      displayEnd,
+      totalPages,
+      pageSizeOptionsFormatted,
+      onPageChange,
+      onPageSizeChange
     };
-  }
+  },
 };
 </script>
 
@@ -129,5 +199,13 @@ export default {
 
 .sort-select {
   width: 150px;
+}
+
+.page-size-select {
+  width: 120px;
+}
+
+.pagination-row :deep(.pagination) {
+  margin-bottom: 0;
 }
 </style>

--- a/client/src/components/facetsearch/Search2.vue
+++ b/client/src/components/facetsearch/Search2.vue
@@ -72,13 +72,18 @@
         </b-col>
 
         <!-- Results -->
-        <b-col md="9" class="results">
+        <b-col ref="resultsCol" md="9" class="results">
           <ResultHeader2
             :current-count="results.length"
             :total-count="totalCount"
             :search-total-count="searchTotalCount"
             :filters="activeFiltersDisplay"
             :loading="isLoading"
+            :current-page="currentPage"
+            :current-page-size="pageSize"
+            :page-size-options="pageSizeOptions"
+            @page-change="handlePageChange"
+            @page-size-change="handlePageSizeChange"
           />
 
           <!-- Error Display -->
@@ -99,7 +104,7 @@
 </template>
 
 <script>
-import { onMounted, provide, watch, computed } from 'vue';
+import { onMounted, provide, watch, computed, ref, nextTick } from 'vue';
 import { useRoute } from 'vue-router';
 import { useSearch } from '@/composables/useSearch.js';
 import { useConfig } from '@/composables/useConfig.js';
@@ -125,6 +130,25 @@ export default {
     const { config, facets } = useConfig();
 
     const search = useSearch(config);
+    const resultsCol = ref(null);
+    const scrollResultsToTop = async () => {
+      await nextTick();
+      const el = resultsCol.value?.$el || resultsCol.value;
+      if (!el || typeof el.getBoundingClientRect !== 'function') return;
+      const top = window.scrollY + el.getBoundingClientRect().top - 12;
+      window.scrollTo({ top, behavior: 'smooth' });
+    };
+
+    const handlePageChange = (page) => {
+      search.setPage(page);
+      void scrollResultsToTop();
+    };
+
+    const handlePageSizeChange = (size) => {
+      search.setPageSize(size);
+      void scrollResultsToTop();
+    };
+
 
     const resourceTypeFacet = computed(() =>
       (facets.value || []).find((f) => f.field === 'resourceType')
@@ -155,6 +179,9 @@ export default {
       ...search,
       resourceTypeFacet,
       primaryFacets,
+      resultsCol,
+      handlePageChange,
+      handlePageSizeChange,
     };
   }
 };

--- a/client/src/composables/useSearch.js
+++ b/client/src/composables/useSearch.js
@@ -66,6 +66,13 @@ export function useSearch(configOrRef) {
     set: (value) => filterStateManager.setResourceType(value)
   });
   const activeFilters = computed(() => state.activeFilters);
+  const currentPage = computed(() => state.page || 1);
+  const pageSize = computed(() => state.limit || Number(unref(configOrRef)?.LIMIT_DEFAULT || 10));
+  const pageSizeOptions = computed(() => {
+    const fromConfig = unref(configOrRef)?.LIMIT_OPTIONS;
+    if (Array.isArray(fromConfig) && fromConfig.length > 0) return fromConfig.map((v) => Number(v));
+    return [10, 50, 100];
+  });
   const hasActiveFilters = computed(() => filterStateManager.hasActiveFilters.value);
   const activeFiltersDisplay = computed(() => filterStateManager.getActiveFiltersForDisplay());
   const filterCount = computed(() => filterStateManager.getFilterCount());
@@ -98,6 +105,14 @@ export function useSearch(configOrRef) {
     await filterStateManager.executeQuery();
   };
 
+  const setPage = (page) => {
+    filterStateManager.setPage(page);
+  };
+
+  const setPageSize = (limit) => {
+    filterStateManager.setLimit(limit);
+  };
+
   const updateFromUrl = (urlParams) => {
     filterStateManager.updateFromUrl(urlParams);
   };
@@ -115,7 +130,7 @@ export function useSearch(configOrRef) {
   };
 
   watch(
-    [textQuery, resourceType, searchExactMatch, activeFilters],
+    [textQuery, resourceType, searchExactMatch, activeFilters, currentPage, pageSize],
     () => {
       updateUrl();
     },
@@ -132,6 +147,9 @@ export function useSearch(configOrRef) {
     searchExactMatch,
     resourceType,
     activeFilters,
+    currentPage,
+    pageSize,
+    pageSizeOptions,
     hasActiveFilters,
     activeFiltersDisplay,
     filterCount,
@@ -142,6 +160,8 @@ export function useSearch(configOrRef) {
     clearAllFilters,
     isFilterActive,
     executeSearch,
+    setPage,
+    setPageSize,
     updateFromUrl,
     getUrlParams,
     updateUrl,

--- a/client/src/services/FilterStateManager.js
+++ b/client/src/services/FilterStateManager.js
@@ -10,6 +10,8 @@ export class FilterStateManager {
       textQuery: '',
       searchExactMatch: true,
       resourceType: 'all',
+      page: 1,
+      limit: Number(config?.LIMIT_DEFAULT ?? 10),
       activeFilters: {},
       isLoading: false,
       results: [],
@@ -29,18 +31,22 @@ export class FilterStateManager {
   setupWatchers() {
     watch(() => this.state.textQuery, () => {
       if (this.isSyncingFromUrl) return;
+      this.resetToFirstPage();
       this.debouncedExecuteQuery();
     });
     watch(() => this.state.activeFilters, () => {
       if (this.isSyncingFromUrl) return;
+      this.resetToFirstPage();
       this.executeQuery();
     }, { deep: true });
     watch(() => this.state.resourceType, () => {
       if (this.isSyncingFromUrl) return;
+      this.resetToFirstPage();
       this.executeQuery();
     });
     watch(() => this.state.searchExactMatch, () => {
       if (this.isSyncingFromUrl) return;
+      this.resetToFirstPage();
       this.executeQuery();
     });
   }
@@ -60,8 +66,8 @@ export class FilterStateManager {
       searchExactMatch: this.state.searchExactMatch,
       resourceType: this.state.resourceType,
       filters: this.state.activeFilters,
-      limit: Number(this.config?.LIMIT_DEFAULT ?? 10),
-      offset: 0
+      limit: Number(this.state.limit || this.config?.LIMIT_DEFAULT || 10),
+      offset: Math.max(0, (Number(this.state.page || 1) - 1) * Number(this.state.limit || this.config?.LIMIT_DEFAULT || 10))
     }));
   }
 
@@ -125,6 +131,31 @@ export class FilterStateManager {
 
   setSearchExactMatch(exact) {
     this.state.searchExactMatch = !!exact;
+  }
+
+  setPage(page) {
+    const parsed = parseInt(page, 10);
+    const nextPage = Number.isFinite(parsed) && parsed > 0 ? parsed : 1;
+    if (nextPage === this.state.page) return;
+    this.state.page = nextPage;
+    void this.executeQuery();
+  }
+
+  setLimit(limit) {
+    const parsed = parseInt(limit, 10);
+    const nextLimit = Number.isFinite(parsed) && parsed > 0
+      ? parsed
+      : Number(this.config?.LIMIT_DEFAULT ?? 10);
+    if (nextLimit === this.state.limit && this.state.page === 1) return;
+    this.state.limit = nextLimit;
+    this.resetToFirstPage();
+    void this.executeQuery();
+  }
+
+  resetToFirstPage() {
+    if (this.state.page !== 1) {
+      this.state.page = 1;
+    }
   }
 
   hasActiveFacetFilters(filters) {
@@ -209,7 +240,7 @@ export class FilterStateManager {
    * @param {string | URLSearchParams | Record<string, unknown>} urlParams - route.query or search string
    */
   updateFromUrl(urlParams) {
-    const reserved = new Set(['q', 'resourceType', 'searchExactMatch']);
+    const reserved = new Set(['q', 'resourceType', 'searchExactMatch', 'page', 'limit']);
 
     /** @type {Map<string, string[]>} */
     const byKey = new Map();
@@ -243,6 +274,14 @@ export class FilterStateManager {
     const ex = exArr && exArr[0];
     const nextSearchExactMatch =
       ex === undefined || ex === '' ? true : ex === 'true';
+    const nextPageRaw = (byKey.get('page') || ['1'])[0] || '1';
+    const nextLimitRaw = (byKey.get('limit') || [String(this.config?.LIMIT_DEFAULT ?? 10)])[0];
+    const parsedPage = parseInt(nextPageRaw, 10);
+    const parsedLimit = parseInt(nextLimitRaw, 10);
+    const nextPage = Number.isFinite(parsedPage) && parsedPage > 0 ? parsedPage : 1;
+    const nextLimit = Number.isFinite(parsedLimit) && parsedLimit > 0
+      ? parsedLimit
+      : Number(this.config?.LIMIT_DEFAULT ?? 10);
 
     const nextActiveFilters = {};
 
@@ -282,6 +321,8 @@ export class FilterStateManager {
       this.state.textQuery === nextTextQuery &&
       this.state.resourceType === nextResourceType &&
       this.state.searchExactMatch === nextSearchExactMatch &&
+      this.state.page === nextPage &&
+      this.state.limit === nextLimit &&
       this.areFiltersEqual(this.state.activeFilters, nextActiveFilters);
     if (unchanged) {
       return;
@@ -291,9 +332,13 @@ export class FilterStateManager {
     this.state.textQuery = nextTextQuery;
     this.state.resourceType = nextResourceType;
     this.state.searchExactMatch = nextSearchExactMatch;
+    this.state.page = nextPage;
+    this.state.limit = nextLimit;
     this.state.activeFilters = nextActiveFilters;
-    this.isSyncingFromUrl = false;
-    void this.executeQuery();
+    queueMicrotask(() => {
+      this.isSyncingFromUrl = false;
+      void this.executeQuery();
+    });
   }
 
   areFilterValuesEqual(a, b) {
@@ -343,6 +388,15 @@ export class FilterStateManager {
 
     if (this.state.resourceType && this.state.resourceType !== 'all') {
       params.set('resourceType', this.state.resourceType);
+    }
+
+    if (this.state.page > 1) {
+      params.set('page', String(this.state.page));
+    }
+
+    const defaultLimit = Number(this.config?.LIMIT_DEFAULT ?? 10);
+    if (this.state.limit !== defaultLimit) {
+      params.set('limit', String(this.state.limit));
     }
 
     params.set(

--- a/client/src/services/FilterStateManager.js
+++ b/client/src/services/FilterStateManager.js
@@ -232,8 +232,8 @@ export class FilterStateManager {
   }
 
   shouldExecuteQuery() {
-    return this.state.textQuery.trim() !== '' ||
-           Object.keys(this.state.activeFilters).length > 0;
+    // Empty keyword should still execute a browse query and return results.
+    return true;
   }
 
   /**
@@ -325,6 +325,11 @@ export class FilterStateManager {
       this.state.limit === nextLimit &&
       this.areFiltersEqual(this.state.activeFilters, nextActiveFilters);
     if (unchanged) {
+      // On first load, route/query can match default state exactly.
+      // Still execute once so empty-keyword browse mode populates results.
+      if (!this.state.lastQuery && this.shouldExecuteQuery()) {
+        void this.executeQuery();
+      }
       return;
     }
 


### PR DESCRIPTION
Closes: #230 #266 

##  Description

### Summary
- Add pagination to Search2 results with URL-synced state:
  - `page` and `limit` query params
  - page size selector
  - page navigation controls
  - correct offset-based fetching and result range display
- Keep pagination behavior consistent by resetting to page 1 when search inputs change:
  - keyword text
  - exact match toggle
  - resource type
  - active facet filters
  - page size
- Enable “browse-all” behavior for empty keyword searches:
  - when search text is empty, execute a no-keyword query
  - show initial/full results (subject to limit) instead of blank/no-results state
- Ensure initial route load executes once even when query state matches defaults, so empty-keyword landing is populated.

### User-facing behavior changes
- Search2 now shows page navigation and `X / page` controls.
- URL reflects paging state and supports deep-linking/reload/back-forward for paged results.
- Opening Search2 with no keyword now shows results (browse mode), not an empty page.

### Technical notes
- Pagination and URL sync logic is managed in `FilterStateManager` + `useSearch`.
- Result header now renders paging controls and range text (e.g., `Showing 101-150 of N results`).
- Empty-keyword execution is implemented as behavior gating only; no replacement of existing optimized query-building architecture.

### Files changed
- `client/src/services/FilterStateManager.js`
- `client/src/composables/useSearch.js`
- `client/src/components/facetsearch/ResultHeader2.vue`
- `client/src/components/facetsearch/Search2.vue`

### Test plan
- [ ] Open `#/Search2?q=water` and verify pagination controls appear.
- [ ] Change page and confirm URL updates with `page` and results update accordingly.
- [ ] Change page size and confirm URL `limit` updates and page resets to 1.
- [ ] Apply/remove filters and verify page resets to 1.
- [ ] Open `#/Search2` (empty keyword) and verify results are shown (not blank/no-results).
- [ ] Reload on a deep link (e.g., `#/Search2?q=water&page=3&limit=50`) and verify state and results are restored.