### PR TITLE
Restyle search result cards and range facet slider colors

### DIFF
--- a/client/src/components/facetsearch/RangeSliderDepth2.vue
+++ b/client/src/components/facetsearch/RangeSliderDepth2.vue
@@ -177,6 +177,9 @@ export default {
 
 .slider-container {
   margin: 1rem 0;
+  --slider-connect-bg: #18598b;
+  --slider-tooltip-bg: #18598b;
+  --slider-handle-ring-color: rgba(24, 89, 139, 0.188);
 }
 
 .range-labels {

--- a/client/src/components/facetsearch/RangeSliderYear2.vue
+++ b/client/src/components/facetsearch/RangeSliderYear2.vue
@@ -152,6 +152,9 @@ export default {
 
 .slider-container {
   margin: 1rem 0;
+  --slider-connect-bg: #18598b;
+  --slider-tooltip-bg: #18598b;
+  --slider-handle-ring-color: rgba(24, 89, 139, 0.188);
 }
 
 .range-labels {

--- a/client/src/components/facetsearch/ResultItem2.vue
+++ b/client/src/components/facetsearch/ResultItem2.vue
@@ -217,12 +217,8 @@ export default {
 article.result-item-master {
   cursor: pointer;
   margin-top: 0.5em;
-
-  border: {
-    right: 0px;
-    left: 0px;
-  }
-  box-shadow: 0 0 10px 1px black;
+  border: 2px solid $gray-400;
+  box-shadow: none;
 
   &:hover {
     background: {


### PR DESCRIPTION
## Summary
- Replace the soft shadow on Search2 result cards with a solid 2px border for a clearer outline without blur
- Change Year Published, Depth Range, and Temporal Coverage slider colors from the default green to primary blue (`#18598b`) to match the Keywords badge

## Test plan
- [ ] Confirm result cards show a visible border with no shadow
- [ ] Confirm Year Published, Depth Range, and Temporal Coverage sliders use the Keywords badge blue
- [ ] Confirm slider tooltips and focus ring also use the updated blue