### PR TITLE
Batch the per-card connected-tools ASK into one SELECT per results page

### DIFF
--- a/client/public/config/config.yaml
+++ b/client/public/config/config.yaml
@@ -30,6 +30,7 @@ THROUGHPUTDB_URL: https://throughputdb.com/api/ccdrs/annotations
 QUERY_ENGINE: qlever
 SPARQL_QUERY: sparql_query.rq
 SPARQL_HASTOOLS: sparql_hastools.rq
+SPARQL_HASTOOLS_BATCH: sparql_hastools_batch.rq
 SPARQL_TOOLS_WEBSERVICE: sparql_gettools_webservice.rq
 SPARQL_TOOLS_DOWNLOAD: sparql_gettools_download.rq
 SPARQL_RELATED_DATA: sparql_relateddatafilename.rq

--- a/client/public/config/config_qlever.yaml
+++ b/client/public/config/config_qlever.yaml
@@ -30,6 +30,7 @@ THROUGHPUTDB_URL: https://throughputdb.com/api/ccdrs/annotations
 QUERY_ENGINE: qlever
 SPARQL_QUERY: sparql_query.rq
 SPARQL_HASTOOLS: sparql_hastools.rq
+SPARQL_HASTOOLS_BATCH: sparql_hastools_batch.rq
 SPARQL_TOOLS_WEBSERVICE: sparql_gettools_webservice.rq
 SPARQL_TOOLS_DOWNLOAD: sparql_gettools_download.rq
 SPARQL_RELATED_DATA: sparql_relateddatafilename.rq

--- a/client/public/config/config_qlever_20.yaml
+++ b/client/public/config/config_qlever_20.yaml
@@ -30,6 +30,7 @@ THROUGHPUTDB_URL: https://throughputdb.com/api/ccdrs/annotations
 QUERY_ENGINE: qlever
 SPARQL_QUERY: sparql_query.rq
 SPARQL_HASTOOLS: sparql_hastools.rq
+SPARQL_HASTOOLS_BATCH: sparql_hastools_batch.rq
 SPARQL_TOOLS_WEBSERVICE: sparql_gettools_webservice.rq
 SPARQL_TOOLS_DOWNLOAD: sparql_gettools_download.rq
 SPARQL_RELATED_DATA: sparql_relateddatafilename.rq

--- a/client/public/config/config_qlever_and_or.yaml
+++ b/client/public/config/config_qlever_and_or.yaml
@@ -30,6 +30,7 @@ THROUGHPUTDB_URL: https://throughputdb.com/api/ccdrs/annotations
 QUERY_ENGINE: qlever
 SPARQL_QUERY: sparql_query.rq
 SPARQL_HASTOOLS: sparql_hastools.rq
+SPARQL_HASTOOLS_BATCH: sparql_hastools_batch.rq
 SPARQL_TOOLS_WEBSERVICE: sparql_gettools_webservice.rq
 SPARQL_TOOLS_DOWNLOAD: sparql_gettools_download.rq
 SPARQL_RELATED_DATA: sparql_relateddatafilename.rq

--- a/client/public/config/config_qlever_localhost.yaml
+++ b/client/public/config/config_qlever_localhost.yaml
@@ -30,6 +30,7 @@ THROUGHPUTDB_URL: https://throughputdb.com/api/ccdrs/annotations
 QUERY_ENGINE: qlever
 SPARQL_QUERY: sparql_query.rq
 SPARQL_HASTOOLS: sparql_hastools.rq
+SPARQL_HASTOOLS_BATCH: sparql_hastools_batch.rq
 SPARQL_TOOLS_WEBSERVICE: sparql_gettools_webservice.rq
 SPARQL_TOOLS_DOWNLOAD: sparql_gettools_download.rq
 SPARQL_RELATED_DATA: sparql_relateddatafilename.rq

--- a/client/public/queries/blazegraph/sparql_hastools_batch.txt
+++ b/client/public/queries/blazegraph/sparql_hastools_batch.txt
@@ -1,0 +1,32 @@
+# batched version of sparql_hastools.txt: one query answers the
+# "connected tools" badge for a whole page of results.
+# ${gvalues} is a space-separated list of graph IRIs, e.g. <urn:a> <urn:b>
+PREFIX schema:  <https://schema.org/>
+PREFIX schemaold:  <http://schema.org/>
+SELECT DISTINCT ?g
+WHERE {
+  VALUES ?g { ${gvalues} }
+  GRAPH ?g
+	  {
+		{
+		  ?s schemaold:distribution|schema:distribution ?dist .
+		  ?dist  schemaold:encodingFormat|schema:encodingFormat ?type .
+		  ?dist schemaold:contentUrl|schema:contentUrl|schema:url|schemaold:url  ?curl
+		}
+		UNION {
+		  VALUES (?dataset) { ( schema:Dataset ) ( schemaold:Dataset ) }
+		  ?s a ?dataset .
+		  ?s  schemaold:encodingFormat|schema:encodingFormat ?type .
+		  }
+	 }
+	 BIND (str(?type) as ?label)
+	 SERVICE <${ecrr_service}> {
+	  GRAPH <${ecrr_graph}>
+	   {
+		  ?rrs schema:supportingData ?df.
+			  ?df schema:encodingFormat  ?label ;
+				  schema:position "input".
+			  ?rrs schema:name ?name.
+	   }
+   }
+}

--- a/client/public/queries/qlever/sparql_hastools_batch.rq
+++ b/client/public/queries/qlever/sparql_hastools_batch.rq
@@ -1,0 +1,33 @@
+# run in a DATASET namespace
+# batched version of sparql_hastools.rq: one query answers the
+# "connected tools" badge for a whole page of results.
+# ${gvalues} is a space-separated list of graph IRIs, e.g. <urn:a> <urn:b>
+PREFIX schema:  <https://schema.org/>
+PREFIX schemaold:  <http://schema.org/>
+PREFIX ecrr: <https://qlever.geocodes-aws-dev.earthcube.org/graphspace/ecrr>
+SELECT DISTINCT ?g
+WHERE {
+  VALUES ?g { ${gvalues} }
+  GRAPH ?g
+	  {
+		{
+		  ?s schemaold:distribution|schema:distribution ?dist .
+		  ?dist  schemaold:encodingFormat|schema:encodingFormat ?type .
+		  ?dist schemaold:contentUrl|schema:contentUrl|schema:url|schemaold:url  ?curl
+		}
+		UNION {
+		  VALUES (?dataset) { ( schema:Dataset ) ( schemaold:Dataset ) }
+		  ?s a ?dataset .
+		  ?s  schemaold:encodingFormat|schema:encodingFormat ?type .
+		  }
+	 }
+	 BIND (str(?type) as ?label)
+	 SERVICE ecrr: {
+
+		  ?rrs schema:supportingData ?df.
+			  ?df schema:encodingFormat  ?label ;
+				  schema:position "input".
+			  ?rrs schema:name ?name.
+
+   }
+}

--- a/client/src/components/facetsearch/ResultItem2.vue
+++ b/client/src/components/facetsearch/ResultItem2.vue
@@ -64,7 +64,6 @@
 
 <script>
 import _ from "lodash";
-import { mapActions, mapGetters } from "vuex";
 import localforage from "localforage";
 import { normalizeDatasetGraphIri } from "@/utils/datasetIdentifiers.js";
 
@@ -84,15 +83,26 @@ export default {
       type: Object,
       default: () => ({}),
     },
+    /** From Results2 — graph IRI -> boolean, filled by one batched query per page. */
+    connectedToolsMap: {
+      type: Object,
+      default: () => ({}),
+    },
   },
   data() {
     return {
-      connectedTools: undefined,
       collectionNames: undefined,
     };
   },
   computed: {
-    ...mapGetters(["getConnectedTool"]),
+    // undefined (spinner) until Results2's batched query fills the map;
+    // do not read the store's LRU cache here — lru-cache get() mutates
+    // recency state, which loops under Vue reactivity
+    connectedTools() {
+      const gg = this.result.g;
+      if (!gg) return false;
+      return this.connectedToolsMap[gg];
+    },
     resourceTypeLower() {
       return String(this.result.resourceType || "data").toLowerCase();
     },
@@ -110,11 +120,9 @@ export default {
     },
   },
   mounted() {
-    this.hasTool();
     this.inCollection();
   },
   methods: {
-    ...mapActions(["hasConnectedTools"]),
     storageKey() {
       return this.result.g || this.result.subj || "";
     },
@@ -185,27 +193,6 @@ export default {
         autoHideDelay: 5000,
         appendToast: false,
       });
-    },
-    hasTool() {
-      const self = this;
-      const gg = self.result.g;
-      if (!gg) {
-        self.connectedTools = false;
-        return;
-      }
-      if (self.getConnectedTool(gg)) {
-        self.connectedTools = self.getConnectedTool(gg);
-      } else {
-        self
-          .hasConnectedTools(gg)
-          .then(function (o) {
-            self.connectedTools = o;
-          })
-          .catch((err) => {
-            self.connectedTools = false;
-            console.info(err);
-          });
-      }
     },
   },
 };

--- a/client/src/components/facetsearch/Results2.vue
+++ b/client/src/components/facetsearch/Results2.vue
@@ -21,12 +21,14 @@
         :result="result"
         :index="index"
         :active-filters="activeFilters"
+        :connected-tools-map="connectedToolsMap"
       />
     </div>
   </div>
 </template>
 
 <script>
+import { mapActions } from 'vuex';
 import ResultItem2 from './ResultItem2.vue';
 
 export default {
@@ -48,6 +50,43 @@ export default {
     activeFilters: {
       type: Object,
       default: () => ({})
+    }
+  },
+
+  data() {
+    return {
+      // graph IRI -> boolean; undefined while the batch query is in flight
+      connectedToolsMap: {},
+      toolsRequestId: 0
+    };
+  },
+
+  watch: {
+    results: {
+      immediate: true,
+      handler(newResults) {
+        this.fetchConnectedTools(newResults);
+      }
+    }
+  },
+
+  methods: {
+    ...mapActions(['hasConnectedToolsBatch']),
+    async fetchConnectedTools(results) {
+      const requestId = ++this.toolsRequestId;
+      this.connectedToolsMap = {};
+      const graphs = [...new Set((results || []).map((r) => r.g).filter(Boolean))];
+      if (graphs.length === 0) return;
+      try {
+        const map = await this.hasConnectedToolsBatch(graphs);
+        if (requestId !== this.toolsRequestId) return; // results changed mid-flight
+        this.connectedToolsMap = map;
+      } catch (err) {
+        console.info('fetchConnectedTools:' + err);
+        if (requestId !== this.toolsRequestId) return;
+        // stop the per-card spinners; badge simply not shown
+        this.connectedToolsMap = Object.fromEntries(graphs.map((g) => [g, false]));
+      }
     }
   }
 };

--- a/client/src/services/queryService.js
+++ b/client/src/services/queryService.js
@@ -92,6 +92,7 @@ class QueryService {
     const commonQueries = [
       "SPARQL_QUERY",
       "SPARQL_HASTOOLS",
+      "SPARQL_HASTOOLS_BATCH",
       "SPARQL_TOOLS_WEBSERVICE",
       "SPARQL_TOOLS_DOWNLOAD",
       "SPARQL_RELATED_DATA",

--- a/client/src/state.js
+++ b/client/src/state.js
@@ -852,18 +852,20 @@ export const store = _createStore({
         ecrr_graph: facetsConfig.ECRR_GRAPH,
       });
 
+      // POST (not GET): the VALUES clause holds one IRI per visible result,
+      // so at large page sizes (1000/5000) the query can exceed URL length limits.
+      const batchParams = new URLSearchParams();
+      batchParams.append("query", batchQuery);
+      batchParams.append("timeout", facetsConfig.BLAZEGRAPH_TIMEOUT || 60);
+      batchParams.append("queryLn", "sparql");
       const config = {
         url: facetsConfig.TRIPLESTORE_URL,
-        method: "get",
+        method: "post",
         headers: {
           Accept: "application/sparql-results+json",
-          "Content-Type": "application/json",
+          "Content-Type": "application/x-www-form-urlencoded",
         },
-        params: {
-          query: batchQuery,
-          timeout: facetsConfig.BLAZEGRAPH_TIMEOUT || 60,
-          queryLn: "sparql",
-        },
+        data: batchParams,
       };
       console.log(
         "hasConnectedToolsBatch:select: " + uncached.length + " graphs"

--- a/client/src/state.js
+++ b/client/src/state.js
@@ -803,6 +803,82 @@ export const store = _createStore({
         return hasTool;
       });
     },
+
+    /* Answer the "connected tools" badge for a whole page of results with a
+     * single SELECT (SPARQL_HASTOOLS_BATCH) instead of one ASK per card.
+     * payload: array of graph IRIs. Returns { graphIri: boolean }. */
+    hasConnectedToolsBatch: async function (context, payload) {
+      const graphs = _.uniq((payload || []).filter(Boolean));
+      const resultMap = {};
+      const uncached = [];
+      for (const g of graphs) {
+        if (context.getters.hasConnectedTool(g)) {
+          resultMap[g] = context.getters.getConnectedTool(g);
+        } else {
+          uncached.push(g);
+        }
+      }
+      if (uncached.length === 0) {
+        return resultMap;
+      }
+
+      const facetsConfig = this.state.FacetsConfig;
+      if (!facetsConfig?.SPARQL_HASTOOLS_BATCH) {
+        // batch query not configured; fall back to one ASK per graph
+        await Promise.all(
+          uncached.map((g) =>
+            context
+              .dispatch("hasConnectedTools", g)
+              .then((hasTool) => {
+                resultMap[g] = hasTool;
+              })
+              .catch((err) => {
+                console.info("hasConnectedToolsBatch:fallback:" + err);
+                resultMap[g] = false;
+              })
+          )
+        );
+        return resultMap;
+      }
+
+      const queryText = await queryService.loadQuery(
+        "SPARQL_HASTOOLS_BATCH",
+        facetsConfig
+      );
+      const resultsTemplate = _.template(queryText, esTemplateOptions);
+      const batchQuery = resultsTemplate({
+        gvalues: uncached.map((g) => "<" + g + ">").join(" "),
+        ecrr_service: facetsConfig.ECRR_TRIPLESTORE_URL,
+        ecrr_graph: facetsConfig.ECRR_GRAPH,
+      });
+
+      const config = {
+        url: facetsConfig.TRIPLESTORE_URL,
+        method: "get",
+        headers: {
+          Accept: "application/sparql-results+json",
+          "Content-Type": "application/json",
+        },
+        params: {
+          query: batchQuery,
+          timeout: facetsConfig.BLAZEGRAPH_TIMEOUT || 60,
+          queryLn: "sparql",
+        },
+      };
+      console.log(
+        "hasConnectedToolsBatch:select: " + uncached.length + " graphs"
+      );
+      const response = await axios.request(config);
+      const withTools = new Set(
+        (response.data?.results?.bindings || []).map((b) => b.g.value)
+      );
+      for (const g of uncached) {
+        const hasTool = withTools.has(g);
+        context.commit("addConnectedTools", { id: g, hasTool: hasTool });
+        resultMap[g] = hasTool;
+      }
+      return resultMap;
+    },
   },
 });
 


### PR DESCRIPTION
## Summary
- Each `ResultItem2` card on Search2 fired its own `SPARQL_HASTOOLS` ASK query (including a federated `SERVICE` call to the ECRR endpoint) on mount, so a page of 20 results meant 20 SPARQL queries.
- `Results2` now dispatches a single `hasConnectedToolsBatch` Vuex action per results page: one `SELECT DISTINCT ?g` with `VALUES ?g { ... }` (new `SPARQL_HASTOOLS_BATCH` query, qlever `.rq` + blazegraph `.txt` variants) answers the "Connected Tools" badge for every visible card at once, and the result map is passed down as a prop. Cards no longer query at all.
- Both true and false answers are committed to the existing `connectedTools` LRU cache, so paging back is fully cached.
- Configs that do not define `SPARQL_HASTOOLS_BATCH` fall back to the old per-graph ASK behavior; the key was added to `config.yaml` and the qlever configs.

## Verification
- Ran the dev client against the live qlever endpoint: a 20-result search rendered 20 "Connected Tools" badges from exactly one SPARQL request (previously 20).
- Confirmed parity on the negative case: graphs where the old ASK returns `false` are omitted by the batch SELECT and render no badge.
- Fixed a Vue "maximum recursive updates" pitfall found during verification: the badge computed must not read the Vuex LRU cache, because `lru-cache.get()` mutates recency state under Vue reactivity; the cache is only touched inside the action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)