### PR TITLE
Use free Esri Ocean basemap for Spatial Filter

### DIFF
--- a/client/src/components/facetsearch/GeoBoundsEditorModal.vue
+++ b/client/src/components/facetsearch/GeoBoundsEditorModal.vue
@@ -52,6 +52,7 @@ import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
 import 'leaflet-draw';
 import 'leaflet-draw/dist/leaflet.draw.css';
+import { addOceanBasemap } from '@/utils/oceanBasemap.js';
 
 const DEFAULT_CENTER = [20, 0];
 const DEFAULT_ZOOM = 2;
@@ -149,9 +150,7 @@ export default {
       if (!mapElement.value || map) return;
 
       map = L.map(mapElement.value).setView(DEFAULT_CENTER, DEFAULT_ZOOM);
-      L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-        attribution: '© OpenStreetMap contributors',
-      }).addTo(map);
+      addOceanBasemap(L, map);
 
       drawnItems = new L.FeatureGroup();
       map.addLayer(drawnItems);

--- a/client/src/components/facetsearch/GeoMapPreview.vue
+++ b/client/src/components/facetsearch/GeoMapPreview.vue
@@ -19,6 +19,7 @@
 import { nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue';
 import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
+import { addOceanBasemap } from '@/utils/oceanBasemap.js';
 
 const DEFAULT_CENTER = [20, 0];
 const DEFAULT_ZOOM = 2;
@@ -81,9 +82,7 @@ export default {
         touchZoom: false,
       }).setView(DEFAULT_CENTER, DEFAULT_ZOOM);
 
-      L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-        attribution: '© OpenStreetMap contributors',
-      }).addTo(map);
+      addOceanBasemap(L, map);
 
       await renderBounds();
     });

--- a/client/src/utils/oceanBasemap.js
+++ b/client/src/utils/oceanBasemap.js
@@ -1,0 +1,25 @@
+/**
+ * Free Esri Ocean basemap tiles (no API key).
+ * Shows bathymetry / ocean geography via GEBCO and related sources.
+ */
+export const OCEAN_BASEMAP_ATTRIBUTION =
+  'Tiles © Esri — Sources: GEBCO, NOAA, CHS, OSU, UNH, CSUMB, National Geographic, DeLorme, NAVTEQ, and Esri';
+
+export const OCEAN_BASE_URL =
+  'https://server.arcgisonline.com/ArcGIS/rest/services/Ocean/World_Ocean_Base/MapServer/tile/{z}/{y}/{x}';
+
+export const OCEAN_REFERENCE_URL =
+  'https://server.arcgisonline.com/ArcGIS/rest/services/Ocean/World_Ocean_Reference/MapServer/tile/{z}/{y}/{x}';
+
+/** Add Esri Ocean base + reference label layers to a Leaflet map. */
+export function addOceanBasemap(L, map) {
+  L.tileLayer(OCEAN_BASE_URL, {
+    attribution: OCEAN_BASEMAP_ATTRIBUTION,
+    maxZoom: 16,
+  }).addTo(map);
+
+  L.tileLayer(OCEAN_REFERENCE_URL, {
+    attribution: OCEAN_BASEMAP_ATTRIBUTION,
+    maxZoom: 16,
+  }).addTo(map);
+}


### PR DESCRIPTION
## Summary
Replace the Spatial Filter OpenStreetMap basemap with the free Esri Ocean basemap so users see ocean bathymetry and geography while setting spatial bounds.

## Changes
- Add shared helper `client/src/utils/oceanBasemap.js` (Esri Ocean Base + Ocean Reference layers, no API key)
- Update Spatial Filter preview and bounds editor maps to use the ocean basemap:
  - `GeoMapPreview.vue`
  - `GeoBoundsEditorModal.vue`

## Why Esri Ocean
We use this map to set the spatial filter extent, not for deep oceanographic analysis. Esri Ocean is free, needs no API key, works with Leaflet XYZ tiles, and gives clearer ocean context than OSM.

## Test plan
- [ ] Open Spatial Filter preview and confirm Esri Ocean tiles load
- [ ] Open bounds editor and confirm the same ocean basemap
- [ ] Draw/edit/confirm a bounding box still works
- [ ] Confirm attribution is shown where attribution controls are enabled
- [ ] Confirm no Mapbox/API key is required for Spatial Filter