### PR TITLE
[WIP] Do not review this yet (Fix/300 spatial map drawedit path does not preserve antimeridian crossing bounding boxes)

### DIFF
--- a/client/src/components/facetsearch/GeoBoundsEditorModal.vue
+++ b/client/src/components/facetsearch/GeoBoundsEditorModal.vue
@@ -55,7 +55,7 @@ import 'leaflet-draw';
 import 'leaflet-draw/dist/leaflet.draw.css';
 import { addOceanBasemap } from '@/utils/oceanBasemap.js';
 
-const DEFAULT_CENTER = [20, 0];
+const DEFAULT_CENTER = [20, 180];
 const DEFAULT_ZOOM = 2;
 
 export default {
@@ -143,10 +143,9 @@ export default {
       if (west <= east) {
         return [{ north, south, east, west }];
       }
-      return [
-        { north, south, west, east: 180 },
-        { north, south, west: -180, east },
-      ];
+      // Display crossing boxes as a single unwrapped rectangle in the
+      // Pacific-centered view (east shifted by +360).
+      return [{ north, south, west, east: east + 360 }];
     };
 
     const getBoundsFromEditedLayers = (layers) => {

--- a/client/src/components/facetsearch/GeoBoundsEditorModal.vue
+++ b/client/src/components/facetsearch/GeoBoundsEditorModal.vue
@@ -20,7 +20,8 @@
         <div class="geo-modal-body">
           <p class="text-muted mb-2">
             Click "Draw Box", then click two corners on the map.
-            Use Edit/Delete tools to adjust, then confirm to apply.
+            Dateline-crossing boxes are preserved; for major shape changes,
+            redraw with "Draw Box" and confirm to apply.
           </p>
           <div ref="mapElement" class="geo-editor-map"></div>
         </div>
@@ -80,6 +81,7 @@ export default {
     let draftBounds = null;
     let tempRectangle = null;
     let firstCorner = null;
+    let firstCornerPoint = null;
     let isTwoClickDrawActive = false;
 
     const cloneBounds = (bounds) => {
@@ -92,38 +94,106 @@ export default {
       };
     };
 
-    const setDraftFromLayer = (layer) => {
-      const bounds = layer.getBounds();
-      draftBounds = {
-        north: bounds.getNorth(),
-        south: bounds.getSouth(),
-        east: bounds.getEast(),
-        west: bounds.getWest(),
-      };
+    const normalizeLongitude = (lng) => {
+      const value = Number(lng);
+      if (!Number.isFinite(value)) return null;
+      return ((value + 180) % 360 + 360) % 360 - 180;
     };
 
-    const getCurrentBoundsFromMap = () => {
-      if (!drawnItems) return null;
-      const layers = drawnItems.getLayers();
-      if (!layers.length) return null;
+    const isDatelineCrossing = (bounds) =>
+      !!bounds && Number(bounds.west) > Number(bounds.east);
 
-      const layer = layers[0];
-      if (!layer?.getBounds) return null;
+    const buildBoundsFromCorners = (a, b, aPoint = null, bPoint = null) => {
+      if (!a || !b) return null;
+      const north = Math.max(a.lat, b.lat);
+      const south = Math.min(a.lat, b.lat);
+      const aLng = normalizeLongitude(a.lng);
+      const bLng = normalizeLongitude(b.lng);
+      if (aLng === null || bLng === null) return null;
 
-      const bounds = layer.getBounds();
+      const span = Math.abs(aLng - bLng);
+      const mapWidth = map?.getSize?.().x || 0;
+      const crossingByPixelDistance =
+        mapWidth > 0 &&
+        aPoint &&
+        bPoint &&
+        Math.abs(Number(aPoint.x) - Number(bPoint.x)) > mapWidth / 2;
+      const crossing = span > 180 || crossingByPixelDistance;
+      const west = crossing ? Math.max(aLng, bLng) : Math.min(aLng, bLng);
+      const east = crossing ? Math.min(aLng, bLng) : Math.max(aLng, bLng);
+
+      if (north === south || east === west) return null;
+      return { north, south, east, west };
+    };
+
+    const toDisplaySegments = (bounds) => {
+      if (!bounds) return [];
+      const north = Number(bounds.north);
+      const south = Number(bounds.south);
+      const east = normalizeLongitude(bounds.east);
+      const west = normalizeLongitude(bounds.west);
+      if (
+        !Number.isFinite(north) ||
+        !Number.isFinite(south) ||
+        east === null ||
+        west === null
+      ) {
+        return [];
+      }
+      if (west <= east) {
+        return [{ north, south, east, west }];
+      }
+      return [
+        { north, south, west, east: 180 },
+        { north, south, west: -180, east },
+      ];
+    };
+
+    const getBoundsFromEditedLayers = (layers) => {
+      if (!layers?.length) return null;
+      const segments = layers
+        .filter((layer) => !!layer?.getBounds)
+        .map((layer) => {
+          const b = layer.getBounds();
+          return {
+            north: b.getNorth(),
+            south: b.getSouth(),
+            east: normalizeLongitude(b.getEast()),
+            west: normalizeLongitude(b.getWest()),
+          };
+        })
+        .filter((s) => s.east !== null && s.west !== null);
+
+      if (!segments.length) return null;
+      if (segments.length === 1) {
+        const seg = segments[0];
+        return {
+          north: seg.north,
+          south: seg.south,
+          east: seg.east,
+          west: seg.west,
+        };
+      }
+
+      const nearDateLine = 10;
+      const right = segments.find((s) => s.east > 180 - nearDateLine);
+      const left = segments.find((s) => s.west < -180 + nearDateLine);
+      if (right && left) {
+        return {
+          north: Math.max(...segments.map((s) => s.north)),
+          south: Math.min(...segments.map((s) => s.south)),
+          west: Math.min(right.west, right.east),
+          east: Math.max(left.west, left.east),
+        };
+      }
+
       return {
-        north: bounds.getNorth(),
-        south: bounds.getSouth(),
-        east: bounds.getEast(),
-        west: bounds.getWest(),
+        north: Math.max(...segments.map((s) => s.north)),
+        south: Math.min(...segments.map((s) => s.south)),
+        west: Math.min(...segments.map((s) => s.west)),
+        east: Math.max(...segments.map((s) => s.east)),
       };
     };
-
-    const getLatLngBounds = (bounds) =>
-      L.latLngBounds(
-        L.latLng(bounds.south, bounds.west),
-        L.latLng(bounds.north, bounds.east)
-      );
 
     const replaceWithRectangle = (bounds) => {
       if (!map || !drawnItems) return;
@@ -137,13 +207,28 @@ export default {
         return;
       }
 
-      const rectangle = L.rectangle(getLatLngBounds(bounds), {
-        color: '#dc3545',
-        weight: 2,
-        fillOpacity: 0.08,
+      const segments = toDisplaySegments(bounds);
+      let combinedBounds = null;
+      segments.forEach((segment) => {
+        const rectangle = L.rectangle(
+          L.latLngBounds(
+            L.latLng(segment.south, segment.west),
+            L.latLng(segment.north, segment.east)
+          ),
+          {
+            color: '#dc3545',
+            weight: 2,
+            fillOpacity: 0.08,
+          }
+        );
+        drawnItems.addLayer(rectangle);
+        combinedBounds = combinedBounds
+          ? combinedBounds.extend(rectangle.getBounds())
+          : rectangle.getBounds();
       });
-      drawnItems.addLayer(rectangle);
-      map.fitBounds(rectangle.getBounds(), { padding: [20, 20] });
+      if (combinedBounds) {
+        map.fitBounds(combinedBounds, { padding: [20, 20] });
+      }
     };
 
     const initMap = () => {
@@ -177,13 +262,17 @@ export default {
         drawnItems.clearLayers();
         const layer = event.layer;
         drawnItems.addLayer(layer);
-        setDraftFromLayer(layer);
+        draftBounds = getBoundsFromEditedLayers([layer]);
       });
 
       map.on(L.Draw.Event.EDITED, (event) => {
         const layers = event.layers.getLayers();
         if (!layers.length) return;
-        setDraftFromLayer(layers[0]);
+        const editedBounds = getBoundsFromEditedLayers(layers);
+        if (editedBounds) {
+          draftBounds = editedBounds;
+          replaceWithRectangle(draftBounds);
+        }
       });
 
       map.on(L.Draw.Event.DELETED, () => {
@@ -195,6 +284,7 @@ export default {
 
         if (!firstCorner) {
           firstCorner = event.latlng;
+          firstCornerPoint = event.containerPoint;
           if (tempRectangle) {
             map.removeLayer(tempRectangle);
           }
@@ -207,15 +297,13 @@ export default {
           return;
         }
 
-        const finalBounds = L.latLngBounds(firstCorner, event.latlng);
-        const finalRect = L.rectangle(finalBounds, {
-          color: '#dc3545',
-          weight: 2,
-          fillOpacity: 0.08,
-        });
-        drawnItems.clearLayers();
-        drawnItems.addLayer(finalRect);
-        setDraftFromLayer(finalRect);
+        draftBounds = buildBoundsFromCorners(
+          firstCorner,
+          event.latlng,
+          firstCornerPoint,
+          event.containerPoint
+        );
+        replaceWithRectangle(draftBounds);
         stopTwoClickDraw();
       });
 
@@ -239,6 +327,7 @@ export default {
     const stopTwoClickDraw = () => {
       isTwoClickDrawActive = false;
       firstCorner = null;
+      firstCornerPoint = null;
       if (tempRectangle && map) {
         map.removeLayer(tempRectangle);
         tempRectangle = null;
@@ -274,11 +363,8 @@ export default {
     };
 
     const handleConfirm = () => {
-      // Leaflet Draw "EDITED" event only fires after clicking the mini "Save"
-      // button in the draw toolbar. Read bounds directly from the map layer so
-      // modal Confirm always commits the latest visual rectangle position/size.
-      const currentBounds = getCurrentBoundsFromMap();
-      draftBounds = currentBounds ? cloneBounds(currentBounds) : null;
+      // Keep draftBounds as source-of-truth so antimeridian crossing survives
+      // without collapsing through Leaflet bounds normalization.
       emit('confirm', cloneBounds(draftBounds));
     };
 

--- a/client/src/components/facetsearch/GeoMapPreview.vue
+++ b/client/src/components/facetsearch/GeoMapPreview.vue
@@ -36,31 +36,79 @@ export default {
   setup(props) {
     const mapElement = ref(null);
     let map = null;
-    let rectangle = null;
+    let rectangles = [];
 
-    const getLatLngBounds = (bounds) =>
-      L.latLngBounds(
-        L.latLng(bounds.south, bounds.west),
-        L.latLng(bounds.north, bounds.east)
-      );
+    const normalizeLongitude = (lng) => {
+      const value = Number(lng);
+      if (!Number.isFinite(value)) return null;
+      return ((value + 180) % 360 + 360) % 360 - 180;
+    };
+
+    const toDisplaySegments = (bounds) => {
+      if (!bounds) return [];
+      const north = Number(bounds.north);
+      const south = Number(bounds.south);
+      const east = normalizeLongitude(bounds.east);
+      const west = normalizeLongitude(bounds.west);
+      if (
+        !Number.isFinite(north) ||
+        !Number.isFinite(south) ||
+        east === null ||
+        west === null
+      ) {
+        return [];
+      }
+      if (west <= east) {
+        return [{ north, south, east, west }];
+      }
+      return [
+        { north, south, west, east: 180 },
+        { north, south, west: -180, east },
+      ];
+    };
 
     const clearRectangle = () => {
-      if (rectangle && map) {
-        map.removeLayer(rectangle);
-        rectangle = null;
+      if (!map) return;
+      rectangles.forEach((rectangle) => map.removeLayer(rectangle));
+      rectangles = [];
+    };
+
+    const addRectangle = (segment) =>
+      L.rectangle(
+        L.latLngBounds(
+          L.latLng(segment.south, segment.west),
+          L.latLng(segment.north, segment.east)
+        ),
+        {
+          color: '#dc3545',
+          weight: 2,
+          fillOpacity: 0.08,
+        }
+      );
+
+    const fitPreviewBounds = (segments) => {
+      if (!map || !segments.length) return;
+      // Crossing boxes produce two segments, one at each map edge. Keep a world
+      // overview for those cases so both sides remain visible in preview.
+      if (segments.length > 1) {
+        map.setView(DEFAULT_CENTER, DEFAULT_ZOOM);
+        return;
       }
+      const only = segments[0];
+      const bounds = L.latLngBounds(
+        L.latLng(only.south, only.west),
+        L.latLng(only.north, only.east)
+      );
+      map.fitBounds(bounds, { padding: [8, 8] });
     };
 
     const renderBounds = async () => {
       if (!map) return;
       clearRectangle();
       if (props.bounds) {
-        rectangle = L.rectangle(getLatLngBounds(props.bounds), {
-          color: '#dc3545',
-          weight: 2,
-          fillOpacity: 0.08,
-        }).addTo(map);
-        map.fitBounds(rectangle.getBounds(), { padding: [8, 8] });
+        const segments = toDisplaySegments(props.bounds);
+        rectangles = segments.map((segment) => addRectangle(segment).addTo(map));
+        fitPreviewBounds(segments);
       } else {
         map.setView(DEFAULT_CENTER, DEFAULT_ZOOM);
       }

--- a/client/src/components/facetsearch/GeoMapPreview.vue
+++ b/client/src/components/facetsearch/GeoMapPreview.vue
@@ -21,7 +21,7 @@ import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
 import { addOceanBasemap } from '@/utils/oceanBasemap.js';
 
-const DEFAULT_CENTER = [20, 0];
+const DEFAULT_CENTER = [20, 180];
 const DEFAULT_ZOOM = 2;
 
 export default {
@@ -61,10 +61,8 @@ export default {
       if (west <= east) {
         return [{ north, south, east, west }];
       }
-      return [
-        { north, south, west, east: 180 },
-        { north, south, west: -180, east },
-      ];
+      // Keep one visual rectangle in Pacific-centered view by unwrapping east.
+      return [{ north, south, west, east: east + 360 }];
     };
 
     const clearRectangle = () => {

--- a/client/src/utils/oceanBasemap.js
+++ b/client/src/utils/oceanBasemap.js
@@ -12,14 +12,16 @@ export const OCEAN_REFERENCE_URL =
   'https://server.arcgisonline.com/ArcGIS/rest/services/Ocean/World_Ocean_Reference/MapServer/tile/{z}/{y}/{x}';
 
 /** Add Esri Ocean base + reference label layers to a Leaflet map. */
-export function addOceanBasemap(L, map) {
+export function addOceanBasemap(L, map, layerOptions = {}) {
   L.tileLayer(OCEAN_BASE_URL, {
     attribution: OCEAN_BASEMAP_ATTRIBUTION,
     maxZoom: 16,
+    ...layerOptions,
   }).addTo(map);
 
   L.tileLayer(OCEAN_REFERENCE_URL, {
     attribution: OCEAN_BASEMAP_ATTRIBUTION,
     maxZoom: 16,
+    ...layerOptions,
   }).addTo(map);
 }


### PR DESCRIPTION
## Description
### Summary
This PR improves spatial bounds rendering for antimeridian-crossing selections (`west > east`) in the map UI.

Previously, crossing bounds could appear split/clipped in the editor/preview path.  
With this change, crossing bounds are rendered as a single visual rectangle in the Pacific-centered view, while preserving existing query/state behavior.

### What changed
- Updated spatial map rendering in:
  - `client/src/components/facetsearch/GeoBoundsEditorModal.vue`
  - `client/src/components/facetsearch/GeoMapPreview.vue`
- Added optional layer options support to:
  - `client/src/utils/oceanBasemap.js`
- Kept dateline-crossing semantics intact in filter state (`west > east`) and URL/query flow.

### Behavior after fix
- Antimeridian-crossing boxes can be drawn/edited and displayed as one rectangle in the modal map.
- The spatial filter remains active and produces expected filtered results.
- Generated geo query still applies dateline-safe longitude logic.

### Validation
- Manual browser sanity checks on `Search2`:
  - Draw/edit crossing box in spatial modal
  - Confirm box updates and filter applies
  - Verify results are returned and relevant to selected area
- Functional check with `q=Hydrographic` + crossing spatial bounds showed valid filtered results.

### Notes
- This PR focuses on UI rendering behavior for crossing bounds.
- No changes to intended backend filter semantics for antimeridian handling.