### PR TITLE
[WP] Do not review this yet (Improve Variables Measured facet loading performance and count consistency in Search2)

### DIFF
--- a/client/src/components/facetsearch/FacetText2.vue
+++ b/client/src/components/facetsearch/FacetText2.vue
@@ -107,7 +107,7 @@
 </template>
 
 <script>
-import { ref, computed, inject } from 'vue';
+import { ref, computed, inject, watch } from 'vue';
 import { useFacet } from '@/composables/useSearch.js';
 
 export default {
@@ -129,14 +129,22 @@ export default {
 
     // Local state
     const showAll = ref(false);
-    const isOpen = ref(props.facetConfig.open !== false);
+    const isHeavyFacetType =
+      props.facetConfig.type === 'propertyvalue' ||
+      props.facetConfig.type === 'variablemeasured';
+    const isOpen = ref(isHeavyFacetType ? false : props.facetConfig.open !== false);
     const optionSortMode = ref('count');
 
-    const sortableFacetFields = ['kw', 'placenames'];
-
-    const supportsOptionSort = computed(() =>
-      sortableFacetFields.includes(props.facetConfig.field)
-    );
+    const supportsOptionSort = computed(() => {
+      const field = props.facetConfig.field;
+      const type = props.facetConfig.type;
+      return (
+        field === 'kw' ||
+        field === 'placenames' ||
+        type === 'propertyvalue' ||
+        type === 'variablemeasured'
+      );
+    });
 
     const sortedOptions = computed(() => {
       const opts = facet.options.value;
@@ -167,7 +175,31 @@ export default {
 
     const toggleOpen = () => {
       isOpen.value = !isOpen.value;
+      if (isOpen.value) {
+        facet.enableOptionsLoading();
+      }
     };
+
+    watch(
+      () => isOpen.value,
+      (open) => {
+        if (open) {
+          facet.enableOptionsLoading();
+        }
+      },
+      { immediate: true }
+    );
+
+    watch(
+      () => facet.hasActiveValues.value,
+      (active) => {
+        if (active) {
+          isOpen.value = true;
+          facet.enableOptionsLoading();
+        }
+      },
+      { immediate: true }
+    );
 
     return {
       ...facet,

--- a/client/src/composables/useSearch.js
+++ b/client/src/composables/useSearch.js
@@ -220,6 +220,8 @@ export function useFacet(facetConfig, searchComposable) {
   } = searchComposable;
 
   const field = facetConfig.field;
+  const isHeavyFacetType =
+    facetConfig.type === 'propertyvalue' || facetConfig.type === 'variablemeasured';
 
   const activeValues = computed(() => {
     return activeFilters.value[field] || [];
@@ -231,6 +233,7 @@ export function useFacet(facetConfig, searchComposable) {
   });
 
   const { options, loading: optionsLoading, loadOptions } = useFacetOptions(searchService, field);
+  const optionsEnabled = ref(!isHeavyFacetType);
 
   const toggleValue = (value) => {
     if (isFilterActive(field, value)) {
@@ -283,11 +286,18 @@ export function useFacet(facetConfig, searchComposable) {
   };
 
   const loadOptionsForCurrentState = async (force = false) => {
+    if (!optionsEnabled.value) return;
     const searchContext = buildSearchContext();
     const key = optionsLoadKey(searchContext);
     if (!force && key === lastLoadedKey.value) return;
     lastLoadedKey.value = key;
     await loadOptions(searchContext);
+  };
+
+  const enableOptionsLoading = () => {
+    if (optionsEnabled.value) return;
+    optionsEnabled.value = true;
+    void loadOptionsForCurrentState(true);
   };
 
   const scheduleOptionsReload = (force = false) => {
@@ -300,6 +310,7 @@ export function useFacet(facetConfig, searchComposable) {
   watch(
     () => optionsLoadKey(buildSearchContext()),
     () => {
+      if (!optionsEnabled.value) return;
       scheduleOptionsReload(false);
     }
   );
@@ -308,12 +319,27 @@ export function useFacet(facetConfig, searchComposable) {
   watch(
     () => filterStateManager.state.lastQueryAt,
     () => {
+      // Heavy facets (e.g. propertyvalue) should avoid the extra forced reload
+      // after every search completion; it duplicates expensive option queries.
+      if (isHeavyFacetType) return;
+      if (!optionsEnabled.value) return;
       if (!filterStateManager.state.lastQuerySignature) return;
       scheduleOptionsReload(true);
     }
   );
 
+  // If a heavy facet has active values (e.g. hydrated from URL), load options so
+  // the selected values and counts can render correctly.
+  watch(
+    hasActiveValues,
+    (active) => {
+      if (active) enableOptionsLoading();
+    },
+    { immediate: true }
+  );
+
   onMounted(() => {
+    if (!optionsEnabled.value) return;
     const ctx = buildSearchContext();
     const hasQuery = String(ctx.textQuery || '').trim() !== '';
     const hasFilters = Object.keys(ctx.filters || {}).length > 0;
@@ -336,7 +362,8 @@ export function useFacet(facetConfig, searchComposable) {
     setValue,
     clearValues,
     isValueActive,
-    loadOptions: loadOptionsForCurrentState
+    loadOptions: loadOptionsForCurrentState,
+    enableOptionsLoading
   };
 }
 

--- a/client/src/services/SearchService.js
+++ b/client/src/services/SearchService.js
@@ -277,6 +277,13 @@ SELECT ?value (0 as ?count) WHERE { FILTER(false) } LIMIT 0
       searchExactMatch = false,
       resourceType = '',
     } = searchContext;
+    const isPropertyValueFacet =
+      facetConfig.type === 'variablemeasured' || facetConfig.type === 'propertyvalue';
+    const configuredLimit = Number(facetConfig.option_limit);
+    const facetOptionLimit =
+      Number.isFinite(configuredLimit) && configuredLimit > 0
+        ? Math.floor(configuredLimit)
+        : (isPropertyValueFacet ? 100 : 200);
 
     // Exclude this facet's own filters to avoid self-filtering options
     const filtersCopy = { ...(currentFilters || {}) };
@@ -304,7 +311,7 @@ WHERE {
     q += `}
 GROUP BY ?value
 ORDER BY DESC(?count) ?value
-LIMIT 200
+LIMIT ${facetOptionLimit}
 `;
     return q;
   }

--- a/client/src/services/SparqlQueryBuilder.js
+++ b/client/src/services/SparqlQueryBuilder.js
@@ -774,7 +774,7 @@ ${typeValues}${typeFilter}${textFilters}${rangeConstraints}    }
 
   /**
    * Generic filter for any schema property that points to a PropertyValue node,
-   * matching on schema:name using CONTAINS (case-insensitive).
+   * matching on schema:name with case-insensitive exact equality.
    *
    * The SPARQL property path is taken from facetConfig.sparql_property; it defaults
    * to schema:variableMeasured so that "variableMeasured" facets work out of the box.
@@ -790,14 +790,14 @@ ${typeValues}${typeFilter}${textFilters}${rangeConstraints}    }
     const nodeVar = `${field}_pv`;
     const typeVar = `${field}_pvType`;
     const nameVar = `${field}_pvName`;
-    const containsExprs = values
-      .map(v => `CONTAINS(LCASE(STR(?${nameVar})), LCASE("${this.escapeValue(v)}"))`)
+    const equalsExprs = values
+      .map(v => `LCASE(STR(?${nameVar})) = LCASE("${this.escapeValue(v)}")`)
       .join(' || ');
     return `  ?subj ${pvProperty} ?${nodeVar} .
   VALUES ?${typeVar} { schema:PropertyValue sschema:PropertyValue }
   ?${nodeVar} a ?${typeVar} .
   ?${nodeVar} schema:name|sschema:name ?${nameVar} .
-  FILTER(${containsExprs}) .\n`;
+  FILTER(${equalsExprs}) .\n`;
   }
 
   /**

--- a/client/src/services/__tests__/propertyvalue-filter.test.js
+++ b/client/src/services/__tests__/propertyvalue-filter.test.js
@@ -1,0 +1,22 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { SparqlQueryBuilder } from '../SparqlQueryBuilder.js';
+
+test('buildPropertyValueNameFilter uses case-insensitive exact match', () => {
+  const builder = new SparqlQueryBuilder({
+    QUERY_ENGINE: 'qlever',
+    FACETS: [{ field: 'variableMeasured', type: 'propertyvalue' }],
+  });
+
+  const fragment = builder.buildPropertyValueNameFilter(
+    'variableMeasured',
+    ['Abundance'],
+    {}
+  );
+
+  assert.match(
+    fragment,
+    /LCASE\(STR\(\?variableMeasured_pvName\)\) = LCASE\("Abundance"\)/
+  );
+  assert.doesNotMatch(fragment, /CONTAINS\(/);
+});


### PR DESCRIPTION
## Description
### Summary
This PR addresses follow-up issues for the `Variables Measured` facet in Search2:
1. Reduce slow initial loading behavior
2. Support both sort modes (Count / A–Z) like other facets
3. Fix count/result mismatch when selecting a value (e.g., `Abundance (1)` returning more than 1 result)

### What changed

#### 1) Performance improvements for `Variables Measured`
- Added lazy option loading for heavy facet types (`propertyvalue` / `variablemeasured`):
  - Options are loaded when the facet is opened (instead of eagerly on initial page load).
- Prevented extra forced post-search reload for heavy facets to avoid duplicate expensive option queries.
- Added a lower default option cap for heavy property-value facets in facet-options query generation:
  - default `LIMIT 100` for `propertyvalue`/`variablemeasured`
  - default `LIMIT 200` for other facets
  - optional override via `facetConfig.option_limit`

#### 2) Sorting support parity
- Enabled facet sort toggle (Count / A–Z) for `propertyvalue` / `variablemeasured` in the shared text facet UI.

#### 3) Count/result consistency fix
- Updated `buildPropertyValueNameFilter` to use case-insensitive exact match instead of `CONTAINS`:
  - from `CONTAINS(LCASE(...), LCASE("value"))`
  - to `LCASE(STR(?name)) = LCASE("value")`
- This aligns selected-value filtering behavior with facet option counts.

### Files changed
- `client/src/components/facetsearch/FacetText2.vue`
- `client/src/composables/useSearch.js`
- `client/src/services/SearchService.js`
- `client/src/services/SparqlQueryBuilder.js`
- `client/src/services/__tests__/propertyvalue-filter.test.js` (new)

### Validation
- Verified Search2 behavior with `q=Hydrographic`.
- Confirmed `Variables Measured` supports both sort modes.
- Confirmed exact-match filter fragment is generated for selected values.
- Ran tests:
  - `node --test src/services/__tests__/propertyvalue-filter.test.js src/services/__tests__/spatial-bounds.test.js`
  - all passing.
